### PR TITLE
Add Single ID CMCF Stage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.8 (2018-08-02)
+
+- added `RawChannelStageConfiguredId` as a new main stage type
+- this allows single ids to be configured on section pages without the need of Papyrus Curation
+- example usecases: Advertorial Footers, oEmbeds (WM, Podcasts,...)
+
+
 ## 1.7 (2018-06-08)
 
 - added `AdminMenuService` for storing menu data on S3

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val buildNumber = Properties.envOrNone("BUILD_NUMBER")
 val isSnapshot = buildNumber.isEmpty
 val PlayVersion = "2.6.15"
 val PlayJsonVersion = "2.6.9"
-val actualVersion: String = s"1.7.${buildNumber.getOrElse("0-local")}"
+val actualVersion: String = s"1.8.${buildNumber.getOrElse("0-local")}"
 
 def withTests(project: Project) = project % "test->test;compile->compile"
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -471,6 +471,24 @@ case class RawChannelStageCurated(override val index: Int,
 }
 
 /**
+  * This stage is a way to curate an escenic id on a section page without needing Papyrus Curation
+  * The intended usage is to place Advertorial Footers or the occasional WM OEmbeds on Section Pages
+  *
+  * @param configuredId An escenic Id to be resolved by the Section Backend
+  */
+case class RawChannelStageConfiguredId(override val index: Int,
+                                  override val `type`: String = RawChannelStage.TypeConfiguredId,
+                                  override val hidden: Boolean = RawChannelStage.HiddenDefault,
+                                  override val trackingName: Option[String],
+                                  override val link: Option[RawSectionReference],
+                                  configuredId: String,
+                                  label: Option[String],
+                                  references: Option[Seq[RawSectionReference]] = None) extends RawChannelStage {
+  lazy val unwrappedReferences: Seq[RawSectionReference] = references.getOrElse(Nil)
+
+}
+
+/**
   * Stage that (currently) represents a Webtrekk Report, e.g. Most-Read
   *
   * @param reportName the name as configured in Webtrekk, should not contain Whitespaces
@@ -505,6 +523,7 @@ object RawChannelStage {
   val TypeCustomModule = "custom-module"
   val TypeCommercial = "commercial"
   val TypeCurated = "curated"
+  val TypeConfiguredId = "configured-id"
   val TypeTracking = "tracking"
   val TypeUnknown = "unknown"
 }

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -33,6 +33,8 @@ object RawFormats {
     Format[RawChannelStageIgnored](rawChannelStageIgnoredReads, throw new scala.Error("[DEV-ERROR] You should not write IgnoredStages"))
   implicit lazy val rawChannelStageCuratedFormat: Format[RawChannelStageCurated] =
     Format[RawChannelStageCurated](rawChannelStageCuratedReads, rawChannelStageCuratedWrites)
+  implicit lazy val rawChannelStageConfiguredIdFormat: Format[RawChannelStageConfiguredId] =
+    Format[RawChannelStageConfiguredId](rawChannelStageConfiguredIdReads, rawChannelStageConfiguredIdWrites)
   implicit lazy val rawChannelStageTrackingFormat: Format[RawChannelStageTracking] =
     Format[RawChannelStageTracking](rawChannelStageTrackingReads, rawChannelStageTrackingWrites)
   implicit lazy val rawChannelStageCommercialFormat: Format[RawChannelStageCommercial] =
@@ -165,6 +167,7 @@ object RawReads {
 
   implicit lazy val rawChannelStageCommercialReads: Reads[RawChannelStageCommercial] = Json.reads[RawChannelStageCommercial]
   implicit lazy val rawChannelStageCuratedReads: Reads[RawChannelStageCurated] = Json.reads[RawChannelStageCurated]
+  implicit lazy val rawChannelStageConfiguredIdReads: Reads[RawChannelStageConfiguredId] = Json.reads[RawChannelStageConfiguredId]
   implicit lazy val rawChannelStageTrackingReads: Reads[RawChannelStageTracking] = Json.reads[RawChannelStageTracking]
 
   implicit lazy val rawChannelStageIgnoredReads = new Reads[RawChannelStageIgnored] {
@@ -299,6 +302,17 @@ object RawWrites {
       (__ \ "hideCuratedStageLabel").writeNullable[Boolean]
     ) (unlift(RawChannelStageCurated.unapply))
 
+  implicit lazy val rawChannelStageConfiguredIdWrites: Writes[RawChannelStageConfiguredId] = (
+    (__ \ "index").write[Int] and
+      OWrites[String](_ ⇒ JsObject(Map("type" → JsString(RawChannelStage.TypeConfiguredId)))) and
+      (__ \ "hidden").write[Boolean] and
+      (__ \ "trackingName").writeNullable[String] and
+      (__ \ "link").writeNullable[RawSectionReference] and
+      (__ \ "configuredId").write[String] and
+      (__ \ "label").writeNullable[String] and
+      (__ \ "references").writeNullable[Seq[RawSectionReference]]
+    ) (unlift(RawChannelStageConfiguredId.unapply))
+
   implicit lazy val rawChannelStageTrackingWrites: Writes[RawChannelStageTracking] = (
     (__ \ "index").write[Int] and
       OWrites[String](_ ⇒ JsObject(Map("type" → JsString(RawChannelStage.TypeTracking)))) and
@@ -320,6 +334,8 @@ object RawWrites {
         Json.toJson(c)(rawChannelStageCommercialWrites)
       case c: RawChannelStageCurated =>
         Json.toJson(c)(rawChannelStageCuratedWrites)
+      case c: RawChannelStageConfiguredId =>
+        Json.toJson(c)(rawChannelStageConfiguredIdWrites)
       case c: RawChannelStageTracking =>
         Json.toJson(c)(rawChannelStageTrackingWrites)
       case err@_ ⇒ throw new IllegalStateException(s"[DEV-ERROR] Missing case-matching for new RawChannelStage: $err")

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawWritesTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawWritesTest.scala
@@ -1,5 +1,6 @@
 package de.welt.contentapi.raw.models
 
+import de.welt.contentapi.raw.models.RawReads.rawChannelStageConfiguredIdReads
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{JsValue, Json}
 
@@ -232,6 +233,52 @@ class RawWritesTest extends PlaySpec {
     }
 
   }
+
+  "RawChannelStageConfiguredId Reads and Writes" must {
+
+      val ConfiguredIdStage = RawChannelStageConfiguredId(
+        index = 0,
+        `type` = RawChannelStage.TypeConfiguredId,
+        hidden = false,
+        trackingName = Some("tracking-name"),
+        link = Some(stageLink),
+        configuredId = "1234567890",
+        label = Some("curated-label"),
+        references = Some(Seq(
+          RawSectionReference(label = Some("ref-label"), path = Some("ref-path"))
+        ))
+      )
+
+      val expectedJson: String =
+        s"""|{
+           |  "index" : 0,
+           |  "type" : "${RawChannelStage.TypeConfiguredId}",
+           |  "hidden" : false,
+           |  "trackingName" : "tracking-name",
+           |  "link" : {
+           |    "path" : "https://www.dick-butt.org"
+           |  },
+           |  "configuredId" : "1234567890",
+           |  "label" : "curated-label",
+           |  "references" : [ {
+           |    "label" : "ref-label",
+           |    "path" : "ref-path"
+           |  } ]
+           |}""".stripMargin
+
+
+    "generate valid JSON from default values" in {
+      val json: JsValue = Json.toJson[RawChannelStageConfiguredId](ConfiguredIdStage)(rawChannelStageConfiguredIdWrites)
+
+      Json.prettyPrint(json) mustBe expectedJson
+    }
+
+    "construct the same object from Json" in {
+      Json.parse(expectedJson).validate[RawChannelStageConfiguredId](rawChannelStageConfiguredIdReads).asOpt mustBe Some(ConfiguredIdStage)
+    }
+
+  }
+
   "RawChannelStageTracking Writes" must {
 
     sealed trait MinimalTrackingStage {


### PR DESCRIPTION
This stage can configure a single Escenic ID as an own stage
e.g. Oembeds or Advertorial Footers on Section Pages