### PR TITLE
[Sitebuilding] Corrected name of the site-building property

### DIFF
--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -243,7 +243,7 @@ object RawReads {
           sponsoring = underlying.get("sponsoring")
             .map(_.as[RawSponsoringConfig])
             .getOrElse(defaults.sponsoring),
-          siteBuilding = underlying.get("site_building")
+          siteBuilding = underlying.get("siteBuilding")
               .map(_.as[RawChannelSiteBuilding])
               .getOrElse(defaults.siteBuilding),
           theme = underlying.get("theme").map(_.as[RawChannelTheme]),


### PR DESCRIPTION
Fixes the bug where site-building fields cannot be stored to the section tree.