### PR TITLE
AbstractService Config adaptions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.5 (2019-08-15)
+- changed the way configs are passed to the `AbstractService` to prevent lazy/null exceptions 
+- Play 2.7.3
+- Scala 2.12.9 and Scala 2.13.0
+
 ## 4.4 (2019-08-13)
 - Added API method to find channels that have a particular commercial stage
 

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ val frontendDependencyManagementSettings = Seq(
 val coreDependencySettings = Seq(
   libraryDependencies ++= Seq(
     "org.mockito" % "mockito-core" % "2.27.0" % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.2" % Test
+    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
   )
 )
 val clientDependencySettings = Seq(
@@ -64,10 +64,9 @@ val clientDependencySettings = Seq(
     "com.amazonaws" % "aws-java-sdk-s3" % AWSVersion,
     "com.amazonaws" % "aws-java-sdk-ssm" % AWSVersion,
     "com.amazonaws" % "aws-java-sdk-sts" % AWSVersion,
-    "com.kenshoo" %% "metrics-play" % "2.7.0_0.8.0",
-//    "de.welt" %% "metrics-play" % "2.7.0_6",
+    "de.welt" %% "metrics-play" % "2.7.3_7",
 
-    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.2" % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test,
     "org.mockito" % "mockito-core" % "2.27.0" % Test
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,16 @@ import scala.util.Properties
 
 val buildNumber = Properties.envOrNone("BUILD_NUMBER")
 val isSnapshot = buildNumber.isEmpty
-val PlayVersion = "2.7.2"
+val PlayVersion = "2.7.3"
 val AWSVersion = "1.11.548"
-val actualVersion: String = s"4.4.${buildNumber.getOrElse("0-local")}"
+val actualVersion: String = s"4.5.${buildNumber.getOrElse("0-local")}"
 
 def withTests(project: Project) = project % "test->test;compile->compile"
 
 val frontendCompilationSettings = Seq(
   organization := "de.welt",
-  scalaVersion := "2.12.8",
-  crossScalaVersions := Seq("2.12.8", "2.13.0-M5"),
+  scalaVersion := "2.12.9",
+  crossScalaVersions := Seq("2.12.9", "2.13.0"),
   version in ThisBuild := s"${actualVersion}_$PlayVersion${if (isSnapshot) "-SNAPSHOT" else ""}",
 
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),

--- a/core/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentBatchService.scala
+++ b/core/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentBatchService.scala
@@ -31,7 +31,7 @@ trait ContentBatchService {
 class ContentBatchServiceImpl @Inject()(ws: WSClient,
                                         metrics: Metrics,
                                         capi: CapiExecutionContext)
-extends AbstractService[ApiBatchResult](ws, metrics, capi) with ContentBatchService {
+extends AbstractService[ApiBatchResult](ws, metrics, ServiceConfiguration("content_batch"), capi) with ContentBatchService {
 
   import de.welt.contentapi.core.models.ApiReads._
   import AbstractService.implicitConversions._
@@ -46,6 +46,5 @@ extends AbstractService[ApiBatchResult](ws, metrics, capi) with ContentBatchServ
     }
   }
 
-  override val config: ServiceConfiguration = ServiceConfiguration("content_batch")
 }
 

--- a/core/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentSearchService.scala
+++ b/core/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentSearchService.scala
@@ -56,14 +56,12 @@ sealed trait ContentSearchService {
 class ContentSearchServiceImpl @Inject()(ws: WSClient,
                                          metrics: Metrics,
                                          override implicit val capi: CapiExecutionContext)
-  extends AbstractService[ApiSearchResponse](ws, metrics, capi) with ContentSearchService {
+  extends AbstractService[ApiSearchResponse](ws, metrics, ServiceConfiguration("search"), capi) with ContentSearchService {
 
   import AbstractService.implicitConversions._
   import de.welt.contentapi.core.models.ApiReads.apiSearchResponseReads
 
   override val validate: WSResponse ⇒ Try[ApiSearchResponse] = response ⇒ (response.json.result \ "response").validate[ApiSearchResponse]
-
-  override val config: ServiceConfiguration = ServiceConfiguration("search")
 
   override def search(apiContentSearch: ApiContentSearch)
                      (implicit requestHeaders: RequestHeaders = Seq.empty): Future[ApiSearchResponse] = {

--- a/core/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
+++ b/core/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
@@ -25,7 +25,7 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 
   trait TestScopeBasicAuth extends AbstractServiceTest.TestScope {
 
-    class TestService extends AbstractService[String](mockWsClient, metricsMock, executionContext) {
+    class TestService extends AbstractService[String](mockWsClient, metricsMock, TestServiceWithBasicAuth, executionContext) {
 
       import AbstractService.implicitConversions._
 
@@ -33,14 +33,13 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 
       override protected def initializeMetricsContext(name: String): Context = mockTimerContext
 
-      override val config: ServiceConfiguration = TestServiceWithBasicAuth
     }
 
   }
 
   trait TestScopeApiKey extends AbstractServiceTest.TestScope {
 
-    class TestService extends AbstractService[String](mockWsClient, metricsMock, executionContext) {
+    class TestService extends AbstractService[String](mockWsClient, metricsMock, TestServiceWithApiKey, executionContext) {
 
       import AbstractService.implicitConversions._
 
@@ -48,7 +47,6 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 
       override protected def initializeMetricsContext(name: String): Context = mockTimerContext
 
-      override val config: ServiceConfiguration = TestServiceWithApiKey
     }
 
   }
@@ -172,7 +170,7 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 
     "configured method will be used" in new AbstractServiceTest.TestScope {
 
-      class TestService extends AbstractService[String](mockWsClient, metricsMock, executionContext) {
+      class TestService extends AbstractService[String](mockWsClient, metricsMock, TestServiceWithApiKey.copy(method = "not-validated-method-name"), executionContext) {
 
         import AbstractService.implicitConversions._
 
@@ -180,7 +178,6 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 
         override protected def initializeMetricsContext(name: String): Context = mockTimerContext
 
-        override val config: ServiceConfiguration = TestServiceWithApiKey.copy(method = "not-validated-method-name")
       }
 
       new TestService().execute(urlArguments = Seq("x"))
@@ -268,6 +265,7 @@ object AbstractServiceTest extends MockitoSugar with TestExecutionContext {
     when(mockRequest.withQueryStringParameters(ArgumentMatchers.any())).thenReturn(mockRequest)
     when(mockRequest.withAuth(anyString, anyString, ArgumentMatchers.eq(WSAuthScheme.BASIC))).thenReturn(mockRequest)
     when(mockRequest.withBody(anyString)(ArgumentMatchers.any())).thenReturn(mockRequest)
+    when(mockRequest.withRequestTimeout(ArgumentMatchers.any())).thenReturn(mockRequest)
 
     when(mockRequest.execute(anyString())).thenReturn(Future {
       responseMock

--- a/core/src/test/scala/de/welt/contentapi/core/client/services/contentapi/CircuitBreakerSpec.scala
+++ b/core/src/test/scala/de/welt/contentapi/core/client/services/contentapi/CircuitBreakerSpec.scala
@@ -27,7 +27,7 @@ class CircuitBreakerSpec extends PlaySpec with MockitoSugar with TestExecutionCo
 
       trait BreakerEnabled extends AbstractServiceTest.TestScope {
 
-        class TestService extends AbstractService[String](mockWsClient, metricsMock, executionContext) {
+        class TestService extends AbstractService[String](mockWsClient, metricsMock, CircuitBreakerSpec.breakerEnabled, executionContext) {
 
           import AbstractService.implicitConversions._
 
@@ -35,7 +35,6 @@ class CircuitBreakerSpec extends PlaySpec with MockitoSugar with TestExecutionCo
 
           override protected def initializeMetricsContext(name: String): Context = mockTimerContext
 
-          override val config: ServiceConfiguration = CircuitBreakerSpec.breakerEnabled
         }
 
       }
@@ -157,7 +156,7 @@ class CircuitBreakerSpec extends PlaySpec with MockitoSugar with TestExecutionCo
 
       trait BreakerDisabled extends AbstractServiceTest.TestScope {
 
-        class TestService extends AbstractService[String](mockWsClient, metricsMock, executionContext) {
+        class TestService extends AbstractService[String](mockWsClient, metricsMock, CircuitBreakerSpec.breakerDisabled, executionContext) {
 
           import AbstractService.implicitConversions._
 
@@ -165,7 +164,6 @@ class CircuitBreakerSpec extends PlaySpec with MockitoSugar with TestExecutionCo
 
           override protected def initializeMetricsContext(name: String): Context = mockTimerContext
 
-          override val config: ServiceConfiguration = CircuitBreakerSpec.breakerDisabled
         }
 
       }

--- a/pressed/src/main/scala/de/welt/contentapi/pressed/client/repository/PressedDiggerClient.scala
+++ b/pressed/src/main/scala/de/welt/contentapi/pressed/client/repository/PressedDiggerClient.scala
@@ -29,13 +29,11 @@ sealed trait PressedDiggerClient {
 class PressedDiggerClientImpl @Inject()(ws: WSClient,
                                         metrics: Metrics,
                                         capi: CapiExecutionContext)
-  extends AbstractService[ApiPressedSectionResponse](ws, metrics, capi) with PressedDiggerClient {
+  extends AbstractService[ApiPressedSectionResponse](ws, metrics, ServiceConfiguration("digger"), capi) with PressedDiggerClient {
 
   import AbstractService.implicitConversions._
 
   override val validate: WSResponse ⇒ Try[ApiPressedSectionResponse] = response ⇒ response.json.result.validate[ApiPressedSectionResponse]
-
-  override val config: ServiceConfiguration = ServiceConfiguration("digger")
 
   override protected[client] def findByPath(path: String)
                                            (implicit requestHeaders: RequestHeaders = Seq.empty): Future[ApiPressedSectionResponse] = {

--- a/pressed/src/main/scala/de/welt/contentapi/pressed/client/services/CiggerService.scala
+++ b/pressed/src/main/scala/de/welt/contentapi/pressed/client/services/CiggerService.scala
@@ -37,14 +37,12 @@ trait CiggerService {
 class CiggerServiceImpl @Inject()(ws: WSClient,
                                   metrics: Metrics,
                                   capi: CapiExecutionContext)
-  extends AbstractService[ApiPressedContentResponse](ws, metrics, capi) with CiggerService {
+  extends AbstractService[ApiPressedContentResponse](ws, metrics, ServiceConfiguration("cigger"), capi) with CiggerService {
 
   import AbstractService.implicitConversions._
 
   override val validate: WSResponse ⇒ Try[ApiPressedContentResponse] = response ⇒ response.json.result
     .validate[ApiPressedContentResponse](PressedReads.apiPressedContentResponseReads)
-
-  override val config: ServiceConfiguration = ServiceConfiguration("cigger")
 
   override def byId(id: String,
                     showRelated: Boolean,

--- a/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiConfigurationTests.scala
+++ b/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiConfigurationTests.scala
@@ -192,10 +192,10 @@ class Raw2ApiConfigurationTests extends PlaySpec {
       apiSiteBuildingConfiguration
         .unwrappedElements
         .flatMap(
-          r ⇒ r.`type` ++ r.unwrappedAssets.flatMap(r2 ⇒ r2.`type`) ++ r.unwrappedAssets.flatMap(r2 ⇒ r2.fields)
+          r ⇒ r.`type` + r.unwrappedAssets.flatMap(r2 ⇒ r2.`type`) + r.unwrappedAssets.flatMap(r2 ⇒ r2.fields)
         ) must contain theSameElementsAs rawChannelSiteBuilding
         .unwrappedElements
-        .flatMap(r ⇒ r.`type` ++ r.unwrappedAssets.flatMap(r2 ⇒ r2.`type`) ++ r.unwrappedAssets.flatMap(r2 ⇒ r2.fields))
+        .flatMap(r ⇒ r.`type` + r.unwrappedAssets.flatMap(r2 ⇒ r2.`type`) + r.unwrappedAssets.flatMap(r2 ⇒ r2.fields))
     }
   }
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/client/services/RawTreeService.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/client/services/RawTreeService.scala
@@ -36,8 +36,9 @@ class RawTreeServiceImpl @Inject()(s3Client: S3Client,
     log.info("RawTree will not be loaded when started in Mode.Test. If you require section data, please mock it.")
   } else {
     // start cron to update the tree automatically
-    capiContext.actorSystem.scheduler.schedule(1.minute, 1.minute, () ⇒ update())
-    update()
+    capiContext.actorSystem.scheduler.schedule(1.minute, 1.minute, new Runnable() {
+      override def run(): Unit = update()
+    } )
   }
 
   def update(): Unit = {

--- a/raw/src/main/scala/de/welt/contentapi/raw/client/services/RawTreeService.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/client/services/RawTreeService.scala
@@ -39,6 +39,7 @@ class RawTreeServiceImpl @Inject()(s3Client: S3Client,
     capiContext.actorSystem.scheduler.schedule(1.minute, 1.minute, new Runnable() {
       override def run(): Unit = update()
     } )
+    update()
   }
 
   def update(): Unit = {


### PR DESCRIPTION
- pass the config as constructor parameter to prevent `null` values due to
the order of class initializations and init code accessing the config early
- Version bumps
-- Play 2.7.3
-- Scala 2.12.9 and Scala 2.13.0