### PR TITLE
NEVER MERGE: sitebuilding migration code for local one time execution

### DIFF
--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -376,7 +376,9 @@ case class RawSponsoringConfig(logo: Option[String] = None,
                                slogan: Option[String] = None,
                                hidden: Boolean = false,
                                link: Option[RawSectionReference] = None,
-                               brandstation: Option[String] = None)
+                               brandstation: Option[String] = None) {
+  lazy val isEmpty: Boolean = this == RawSponsoringConfig()
+}
 
 /**
   * Channel Site-Building. Configure Header, Footer and Sponsoring
@@ -391,13 +393,14 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
 
   lazy val unwrappedSubNavigation: Seq[RawSectionReference] = sub_navigation.getOrElse(Nil)
   lazy val unwrappedElements: Seq[RawElement] = elements.getOrElse(Nil)
+  lazy val unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty)
 
   /**
     * Channel Sitebuilding is empty when:
     *  - it has never been configured (default constructor)
     *  - it was already configured and deleted (consisting only of empty fields map)
     */
-  lazy val isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
+  lazy val isEmpty: Boolean = this == RawChannelSiteBuilding() || fields.isEmpty
 }
 
 /**

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -253,7 +253,7 @@ object RawReads {
           siteBuilding = underlying.get("siteBuilding")
               .map(_.as[RawChannelSiteBuilding])
               .filterNot(_.isEmpty)
-            .orElse(migrateHeaderToSitebuildingFields(
+            .orElse(sitebuildingMigration(
               underlying.get("header").map(_.as[RawChannelHeader]),
               underlying.get("sponsoring").map(_.as[RawSponsoringConfig]))
             ),
@@ -269,7 +269,7 @@ object RawReads {
   }
 
   //noinspection ScalaStyle
-  def migrateHeaderToSitebuildingFields(mrh: Option[RawChannelHeader], ms: Option[RawSponsoringConfig]): Option[RawChannelSiteBuilding] = {
+  def sitebuildingMigration(mrh: Option[RawChannelHeader], ms: Option[RawSponsoringConfig]): Option[RawChannelSiteBuilding] = {
 
     // header (done)
     val headerFields = mrh.map { rh =>
@@ -285,10 +285,10 @@ object RawReads {
     }
 
     // partner header
-    //todo: where to get
+    //todo: where to get partner data
 
     // footer
-    //todo: where to get
+    //todo: where to get footer data
 
     // sponsoring
    val sponsorfields = ms.map { s =>
@@ -298,12 +298,13 @@ object RawReads {
       s.link.map(_.path).foreach(v => fields.+("sponsoring_logo_href" -> v))
       s.slogan.foreach(v => fields.+("sponsoring_slogan" -> v))
       // for "sponsoring_ad_indicator" see "header" above
-      s.brandstation //todo: what to do with this?
+      s.brandstation //todo: what to do with this field?
      fields
     }
 
     if (sponsorfields.isDefined || headerFields.isDefined) {
       Some(RawChannelSiteBuilding(Some(sponsorfields.getOrElse(Map.empty) ++ headerFields.getOrElse(Map.empty)), None, None))
+      // todo: where to get sub_navigation: Option[Seq[RawSectionReference]] and elements: Option[Seq[RawElement]]
     } else None
 
   }

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
@@ -259,4 +259,1036 @@ class RawReadsTest extends PlaySpec {
       stage.get.`type` mustBe RawChannelStage.TypeCurated
     }
   }
+
+  "Migration" must {
+    "migrate old header values to sitebuilding fields" in {
+      val header =
+        """{
+          |      "logo": "kompakt",
+          |      "slogan": "header_old_section_name_slogan",
+          |      "label": "header_old_section_name_label",
+          |      "hidden": false,
+          |      "adIndicator": true,
+          |      "sloganReference": {
+          |        "path": "/header_old_section_name_slogan_link/"
+          |      },
+          |      "headerReference": {
+          |        "path": "/header_old_section_name_header_link/"
+          |      }
+          |    }
+        """.stripMargin
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, None).get
+      val migratedFields = collection.Map(
+        "header_slogan_href"      -> "/header_old_section_name_slogan_link/",
+        "header_slogan"           -> "header_old_section_name_slogan",
+        "sponsoring_ad_indicator" -> "true",
+        "header_logo"             -> "kompakt",
+        "header_hidden"           -> "false",
+        "header_label"            -> "header_old_section_name_label",
+        "header_href"             -> "/header_old_section_name_header_link/"
+      )
+      sitebuilding.fields.getOrElse(Map.empty) mustBe migratedFields
+    }
+
+    "migrate old header references to sitebuilding references" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, None).get
+      sitebuilding.sub_navigation.map(_.size) mustBe Some(2)
+      sitebuilding.sub_navigation mustBe mheader.flatMap(_.sectionReferences)
+    }
+
+    "migrate old sponsoring to sitebuilding" in {
+      val json =
+        """{
+          |      "hidden": false,
+          |      "logo": "70-jahre-wams",
+          |      "slogan": "sponsoring_old_sponsoring_slogan",
+          |      "brandstation": "presented",
+          |      "link": {
+          |        "path": "/sponsoring_old_sponsoring_logo_link/"
+          |      }
+          |    }
+        """.stripMargin
+      val sponsoring = Json.parse(json).validate[RawSponsoringConfig].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(None, sponsoring, None).get
+      sitebuilding.fields.getOrElse(Map.empty) mustBe Map(
+        "sponsoring_logo" -> "70-jahre-wams",
+        "sponsoring_logo_href" -> "/sponsoring_old_sponsoring_logo_link/",
+        "sponsoring_slogan" -> "sponsoring_old_sponsoring_slogan",
+        "sponsoring_hidden" -> "false",
+        "sponsoring_enclosure" -> "presented")
+    }
+
+    "sitebuilding references win over old ones" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_old",
+          |          "path": "/unique_old/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+
+      val siteBuilding =
+        """{
+          |"sub_navigation": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_new",
+          |          "path": "/unique_new/"
+          |        }
+          |      ]
+          |}
+        """.stripMargin
+
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val msiteb = Json.parse(siteBuilding).validate[RawChannelSiteBuilding].asOpt
+
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, msiteb).get
+
+      sitebuilding.sub_navigation mustBe Some(Vector(
+        RawSectionReference(Some("header_old_subnavi_label_1"),Some("/header_old_subnavi_label_1_url/")),
+        RawSectionReference(Some("header_old_subnavi_label_2"),Some("/header_old_subnavi_label_2_url/")),
+        RawSectionReference(Some("unique_new")                ,Some("/unique_new/"))
+      ))
+    }
+
+    "old references are migrated if sitebuilding is empty" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_old",
+          |          "path": "/unique_old/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+
+      val siteBuilding =
+        """{
+          |"sub_navigation": []
+          |}
+        """.stripMargin
+
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val msiteb = Json.parse(siteBuilding).validate[RawChannelSiteBuilding].asOpt
+
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, msiteb).get
+
+      sitebuilding.sub_navigation mustBe Some(Vector(
+        RawSectionReference(Some("header_old_subnavi_label_1"),Some("/header_old_subnavi_label_1_url/")),
+        RawSectionReference(Some("header_old_subnavi_label_2"),Some("/header_old_subnavi_label_2_url/")),
+        RawSectionReference(Some("unique_old")                ,Some("/unique_old/"))
+      ))
+    }
+
+    "migrate old header dropdown to sitebuilding dropdown logo" in {
+      val json =
+        """
+          |{
+          |      "logo": "kompakt"
+          |}
+        """.stripMargin
+      val mHeader = Json.parse(json).validate[RawChannelHeader].asOpt
+      val json2 =
+        """{
+          |      "fields": {
+          |        "header_logo": "header_logo_escenic"
+          |      },
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-header_logo_escenic.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |}""".stripMargin
+      val mSiteb = Json.parse(json2).validate[RawChannelSiteBuilding].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(mHeader, None, mSiteb).get
+      sitebuilding.unwrappedFields("header_logo") mustBe "kompakt"
+      sitebuilding.unwrappedFields("header_logo_escenic") mustBe "header_logo_escenic"
+      sitebuilding.elements.size mustBe 1
+
+    }
+    "migrate old sponsoring dropdown to sitebuilding dropdown logo" in {
+      val json =
+        """
+          |{
+          |      "logo": "kompakt"
+          |}
+        """.stripMargin
+      val mSponsoring = Json.parse(json).validate[RawSponsoringConfig].asOpt
+      val json2 =
+        """{
+          |      "fields": {
+          |        "sponsoring_logo": "sponsoring_logo_escenic"
+          |      },
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-header_logo_escenic.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |}""".stripMargin
+      val mSiteb = Json.parse(json2).validate[RawChannelSiteBuilding].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(None, mSponsoring, mSiteb).get
+      sitebuilding.unwrappedFields("sponsoring_logo") mustBe "kompakt"
+      sitebuilding.unwrappedFields("sponsoring_logo_escenic") mustBe "sponsoring_logo_escenic"
+      sitebuilding.elements.size mustBe 1
+
+    }
+
+
+  }
+
+  "Migration json compare" should {
+
+    "old completely filled, sitebuilding empty" in {
+      val json = """{
+                   |    "metadata": {
+                   |      "title": "",
+                   |      "description": "",
+                   |      "sectionRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "contentRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "sectionBreadcrumbDisabled": false,
+                   |      "keywords": []
+                   |    },
+                   |    "commercial": {
+                   |      "contentTaboola": {
+                   |        "showNetwork": true,
+                   |        "showNews": true,
+                   |        "showWeb": true,
+                   |        "showWebExtended": true
+                   |      },
+                   |      "definesAdTag": false,
+                   |      "definesVideoAdTag": false,
+                   |      "showFallbackAds": true,
+                   |      "disableAdvertisement": false
+                   |    },
+                   |    "articlePromotions": [
+                   |      {
+                   |        "contentId": "",
+                   |        "type": "Advertorial"
+                   |      }
+                   |    ],
+                   |    "header": {
+                   |      "logo": "kompakt",
+                   |      "slogan": "header_old_section_name_slogan",
+                   |      "label": "header_old_section_name_label",
+                   |      "sectionReferences": [
+                   |        {
+                   |          "label": "header_old_subnavi_label_1",
+                   |          "path": "/header_old_subnavi_label_1_url/"
+                   |        },
+                   |        {
+                   |          "label": "header_old_subnavi_label_2",
+                   |          "path": "/header_old_subnavi_label_2_url/"
+                   |        }
+                   |      ],
+                   |      "hidden": false,
+                   |      "adIndicator": true,
+                   |      "sloganReference": {
+                   |        "path": "/header_old_section_name_slogan_link/"
+                   |      },
+                   |      "headerReference": {
+                   |        "path": "/header_old_section_name_header_link/"
+                   |      }
+                   |    },
+                   |    "sponsoring": {
+                   |      "hidden": false,
+                   |      "logo": "70-jahre-wams",
+                   |      "slogan": "sponsoring_old_sponsoring_slogan",
+                   |      "brandstation": "sponsored",
+                   |      "link": {
+                   |        "path": "/sponsoring_old_sponsoring_logo_link/"
+                   |      }
+                   |    },
+                   |    "siteBuilding": {
+                   |      "fields": {
+                   |        "header_label": "",
+                   |        "header_logo": "",
+                   |        "header_href": "",
+                   |        "header_slogan": "",
+                   |        "header_slogan_href": "",
+                   |        "header_hidden": "",
+                   |        "partner_header_button_label": "",
+                   |        "partner_header_button_href": "",
+                   |        "partner_header_mood_image": "",
+                   |        "partner_header_logo": "",
+                   |        "partner_header_hidden": "",
+                   |        "sponsoring_logo": "",
+                   |        "sponsoring_logo_href": "",
+                   |        "sponsoring_slogan": "",
+                   |        "sponsoring_ad_indicator": "",
+                   |        "sponsoring_hidden": "",
+                   |        "sponsoring_enclosure_hidden": "",
+                   |        "sponsoring_enclosure": "",
+                   |        "footer_button_label": "",
+                   |        "footer_button_href": "",
+                   |        "footer_slogan_label": "",
+                   |        "footer_slogan_href": "",
+                   |        "footer_mood_image": "",
+                   |        "footer_logo": "",
+                   |        "footer_legal": "",
+                   |        "footer_hidden": "",
+                   |        "footer_body": "",
+                   |        "partner_header_body": ""
+                   |      },
+                   |      "sub_navigation": [],
+                   |      "elements": []
+                   |    },
+                   |    "master": false,
+                   |    "brand": false,
+                   |    "theme": {
+                   |      "name": ""
+                   |    },
+                   |    "content": {}
+                   |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected = """{
+                      |    "fields": {
+                      |      "header_label": "header_old_section_name_label",
+                      |      "header_logo": "kompakt",
+                      |      "header_logo_escenic": "",
+                      |      "header_href": "/header_old_section_name_header_link/",
+                      |      "header_slogan": "header_old_section_name_slogan",
+                      |      "header_slogan_href": "/header_old_section_name_slogan_link/",
+                      |      "header_hidden": "false",
+                      |      "partner_header_button_label": "",
+                      |      "partner_header_button_href": "",
+                      |      "partner_header_mood_image": "",
+                      |      "partner_header_logo": "",
+                      |      "partner_header_hidden": "",
+                      |      "sponsoring_logo": "70-jahre-wams",
+                      |      "sponsoring_logo_escenic": "",
+                      |      "sponsoring_logo_href": "/sponsoring_old_sponsoring_logo_link/",
+                      |      "sponsoring_slogan": "sponsoring_old_sponsoring_slogan",
+                      |      "sponsoring_ad_indicator": "true",
+                      |      "sponsoring_hidden": "false",
+                      |      "sponsoring_enclosure_hidden": "",
+                      |      "sponsoring_enclosure": "sponsored",
+                      |      "footer_button_label": "",
+                      |      "footer_button_href": "",
+                      |      "footer_slogan_label": "",
+                      |      "footer_slogan_href": "",
+                      |      "footer_mood_image": "",
+                      |      "footer_logo": "",
+                      |      "footer_legal": "",
+                      |      "footer_hidden": "",
+                      |      "footer_body": "",
+                      |      "partner_header_body": ""
+                      |    },
+                      |    "sub_navigation": [
+                      |      {
+                      |        "label": "header_old_subnavi_label_1",
+                      |        "path": "/header_old_subnavi_label_1_url/"
+                      |      },
+                      |      {
+                      |        "label": "header_old_subnavi_label_2",
+                      |        "path": "/header_old_subnavi_label_2_url/"
+                      |      }
+                      |    ],
+                      |    "elements": []
+                      |  }""".stripMargin
+
+      val expectedSitebuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+
+    "sitebuilding completely filled, old empty" in {
+      val json = """{
+                   |    "metadata": {
+                   |      "title": "",
+                   |      "description": "",
+                   |      "sectionRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "contentRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "sectionBreadcrumbDisabled": false,
+                   |      "keywords": []
+                   |    },
+                   |    "commercial": {
+                   |      "contentTaboola": {
+                   |        "showNetwork": true,
+                   |        "showNews": true,
+                   |        "showWeb": true,
+                   |        "showWebExtended": true
+                   |      },
+                   |      "definesAdTag": false,
+                   |      "definesVideoAdTag": false,
+                   |      "showFallbackAds": true,
+                   |      "disableAdvertisement": false
+                   |    },
+                   |    "articlePromotions": [],
+                   |    "header": {
+                   |      "logo": "",
+                   |      "slogan": "",
+                   |      "label": "",
+                   |      "sectionReferences": [],
+                   |      "hidden": false,
+                   |      "adIndicator": false
+                   |    },
+                   |    "sponsoring": {
+                   |      "hidden": false
+                   |    },
+                   |    "siteBuilding": {
+                   |      "fields": {
+                   |        "header_label": "sitebuilding_custom_header_label",
+                   |        "header_logo": "sitebuilding_custom_header_logo_ece_id",
+                   |        "header_href": "/sitebuilding_custom_header_link/",
+                   |        "header_slogan": "sitebuilding_custom_header_slogan",
+                   |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+                   |        "header_hidden": "false",
+                   |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+                   |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+                   |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+                   |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+                   |        "partner_header_hidden": "false",
+                   |        "sponsoring_logo": "sitebuilding_header_sponsoring_logo_ece_id",
+                   |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+                   |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+                   |        "sponsoring_ad_indicator": "true",
+                   |        "sponsoring_hidden": "false",
+                   |        "sponsoring_enclosure_hidden": "false",
+                   |        "sponsoring_enclosure": "presented",
+                   |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+                   |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+                   |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+                   |        "footer_slogan_href": "",
+                   |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+                   |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+                   |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+                   |        "footer_hidden": "false",
+                   |        "general_breadcrumb_hidden": "",
+                   |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+                   |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+                   |      },
+                   |      "sub_navigation": [
+                   |        {
+                   |          "label": "sitebuilding_subnavi_label_1",
+                   |          "path": "/sitebuilding_subnavi_href_1/"
+                   |        },
+                   |        {
+                   |          "label": "sitebuilding_subnavi_label_2",
+                   |          "path": "/sitebuilding_subnavi_href_2/"
+                   |        }
+                   |      ],
+                   |      "elements": [
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "header_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "sponsoring_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "partner_header_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "partner_header_mood_image",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "94x35",
+                   |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/0096585617-ci94x35-wWIDTH/image.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "footer_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "footer_mood_image",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "16x9",
+                   |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/2281353017-ci16x9-wWIDTH/image.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        }
+                   |      ]
+                   |    },
+                   |    "master": false,
+                   |    "brand": false,
+                   |    "theme": {
+                   |      "name": ""
+                   |    },
+                   |    "content": {}
+                   |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected = """{
+                       |      "fields": {
+                       |        "header_label": "sitebuilding_custom_header_label",
+                       |        "header_logo": "",
+                       |        "header_logo_escenic": "sitebuilding_custom_header_logo_ece_id",
+                       |        "header_href": "/sitebuilding_custom_header_link/",
+                       |        "header_slogan": "sitebuilding_custom_header_slogan",
+                       |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+                       |        "header_hidden": "false",
+                       |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+                       |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+                       |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+                       |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+                       |        "partner_header_hidden": "false",
+                       |        "sponsoring_logo": "",
+                       |        "sponsoring_logo_escenic": "sitebuilding_header_sponsoring_logo_ece_id",
+                       |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+                       |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+                       |        "sponsoring_ad_indicator": "true",
+                       |        "sponsoring_hidden": "false",
+                       |        "sponsoring_enclosure_hidden": "false",
+                       |        "sponsoring_enclosure": "presented",
+                       |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+                       |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+                       |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+                       |        "footer_slogan_href": "",
+                       |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+                       |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+                       |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+                       |        "footer_hidden": "false",
+                       |        "general_breadcrumb_hidden": "",
+                       |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+                       |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+                       |      },
+                       |      "sub_navigation": [
+                       |        {
+                       |          "label": "sitebuilding_subnavi_label_1",
+                       |          "path": "/sitebuilding_subnavi_href_1/"
+                       |        },
+                       |        {
+                       |          "label": "sitebuilding_subnavi_label_2",
+                       |          "path": "/sitebuilding_subnavi_href_2/"
+                       |        }
+                       |      ],
+                       |      "elements": [
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "header_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "sponsoring_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "partner_header_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "partner_header_mood_image",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "94x35",
+                       |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/0096585617-ci94x35-wWIDTH/image.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "footer_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "footer_mood_image",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "16x9",
+                       |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/2281353017-ci16x9-wWIDTH/image.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        }
+                       |      ]
+                       |    }""".stripMargin
+
+      val expectedSitebuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+
+    "both completely filled" in {
+      val json = """{
+                   |    "metadata": {
+                   |      "title": "",
+                   |      "description": "",
+                   |      "sectionRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "contentRobots": {
+                   |        "noIndex": false,
+                   |        "noFollow": false
+                   |      },
+                   |      "sectionBreadcrumbDisabled": false,
+                   |      "keywords": []
+                   |    },
+                   |    "commercial": {
+                   |      "contentTaboola": {
+                   |        "showNetwork": true,
+                   |        "showNews": true,
+                   |        "showWeb": true,
+                   |        "showWebExtended": true
+                   |      },
+                   |      "definesAdTag": false,
+                   |      "definesVideoAdTag": false,
+                   |      "showFallbackAds": true,
+                   |      "disableAdvertisement": false
+                   |    },
+                   |    "articlePromotions": [],
+                   |    "header": {
+                   |      "logo": "kompakt",
+                   |      "slogan": "header_old_section_name_slogan",
+                   |      "label": "header_old_section_name_label",
+                   |      "sectionReferences": [
+                   |        {
+                   |          "label": "header_old_subnavi_label_1",
+                   |          "path": "/header_old_subnavi_label_1_url/"
+                   |        },
+                   |        {
+                   |          "label": "header_old_subnavi_label_2",
+                   |          "path": "/header_old_subnavi_label_2_url/"
+                   |        }
+                   |      ],
+                   |      "hidden": false,
+                   |      "adIndicator": true,
+                   |      "sloganReference": {
+                   |        "path": "/header_old_section_name_slogan_link/"
+                   |      },
+                   |      "headerReference": {
+                   |        "path": "/header_old_section_name_header_link/"
+                   |      }
+                   |    },
+                   |    "sponsoring": {
+                   |      "hidden": false,
+                   |      "logo": "70-jahre-wams",
+                   |      "slogan": "sponsoring_old_sponsoring_slogan",
+                   |      "brandstation": "presented",
+                   |      "link": {
+                   |        "path": "/sponsoring_old_sponsoring_logo_link/"
+                   |      }
+                   |    },
+                   |    "siteBuilding": {
+                   |      "fields": {
+                   |        "header_label": "sitebuilding_custom_header_label",
+                   |        "header_logo": "sitebuilding_custom_header_logo_ece_id",
+                   |        "header_href": "/sitebuilding_custom_header_link/",
+                   |        "header_slogan": "sitebuilding_custom_header_slogan",
+                   |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+                   |        "header_hidden": "false",
+                   |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+                   |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+                   |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+                   |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+                   |        "partner_header_hidden": "false",
+                   |        "sponsoring_logo": "sitebuilding_header_sponsoring_logo_ece_id",
+                   |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+                   |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+                   |        "sponsoring_ad_indicator": "true",
+                   |        "sponsoring_hidden": "false",
+                   |        "sponsoring_enclosure_hidden": "false",
+                   |        "sponsoring_enclosure": "presented",
+                   |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+                   |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+                   |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+                   |        "footer_slogan_href": "",
+                   |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+                   |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+                   |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+                   |        "footer_hidden": "false",
+                   |        "general_breadcrumb_hidden": "",
+                   |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+                   |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+                   |      },
+                   |      "sub_navigation": [
+                   |        {
+                   |          "label": "sitebuilding_subnavi_label_1",
+                   |          "path": "/sitebuilding_subnavi_href_1/"
+                   |        },
+                   |        {
+                   |          "label": "sitebuilding_subnavi_label_2",
+                   |          "path": "/sitebuilding_subnavi_href_2/"
+                   |        }
+                   |      ],
+                   |      "elements": [
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "header_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "sponsoring_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "partner_header_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "partner_header_mood_image",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "94x35",
+                   |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/3506586347-ci94x35-wWIDTH/image.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "footer_logo",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "orig",
+                   |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        },
+                   |        {
+                   |          "id": "channel_element",
+                   |          "type": "footer_mood_image",
+                   |          "assets": [
+                   |            {
+                   |              "type": "image",
+                   |              "fields": {
+                   |                "crop": "16x9",
+                   |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/0771358307-ci16x9-wWIDTH/image.jpg"
+                   |              }
+                   |            }
+                   |          ]
+                   |        }
+                   |      ]
+                   |    },
+                   |    "master": false,
+                   |    "brand": false,
+                   |    "theme": {
+                   |      "name": ""
+                   |    },
+                   |    "content": {}
+                   |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected = """{
+                       |      "fields": {
+                       |        "header_label": "sitebuilding_custom_header_label",
+                       |        "header_logo": "kompakt",
+                       |        "header_logo_escenic": "sitebuilding_custom_header_logo_ece_id",
+                       |        "header_href": "/sitebuilding_custom_header_link/",
+                       |        "header_slogan": "sitebuilding_custom_header_slogan",
+                       |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+                       |        "header_hidden": "false",
+                       |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+                       |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+                       |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+                       |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+                       |        "partner_header_hidden": "false",
+                       |        "sponsoring_logo": "70-jahre-wams",
+                       |        "sponsoring_logo_escenic": "sitebuilding_header_sponsoring_logo_ece_id",
+                       |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+                       |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+                       |        "sponsoring_ad_indicator": "true",
+                       |        "sponsoring_hidden": "false",
+                       |        "sponsoring_enclosure_hidden": "false",
+                       |        "sponsoring_enclosure": "presented",
+                       |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+                       |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+                       |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+                       |        "footer_slogan_href": "",
+                       |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+                       |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+                       |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+                       |        "footer_hidden": "false",
+                       |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+                       |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+                       |      },
+                       |      "sub_navigation": [
+                       |        {
+                       |          "label": "sitebuilding_subnavi_label_1",
+                       |          "path": "/sitebuilding_subnavi_href_1/"
+                       |        },
+                       |        {
+                       |          "label": "sitebuilding_subnavi_label_2",
+                       |          "path": "/sitebuilding_subnavi_href_2/"
+                       |        }
+                       |      ],
+                       |      "elements": [
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "header_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "sponsoring_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "partner_header_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "partner_header_mood_image",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "94x35",
+                       |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/3506586347-ci94x35-wWIDTH/image.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "footer_logo",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "orig",
+                       |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        },
+                       |        {
+                       |          "id": "channel_element",
+                       |          "type": "footer_mood_image",
+                       |          "assets": [
+                       |            {
+                       |              "type": "image",
+                       |              "fields": {
+                       |                "crop": "16x9",
+                       |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/0771358307-ci16x9-wWIDTH/image.jpg"
+                       |              }
+                       |            }
+                       |          ]
+                       |        }
+                       |      ]
+                       |    }""".stripMargin
+
+      val expectedSitebuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+  }
+
+
+
+
 }


### PR DESCRIPTION
this PR will never be merged, it will be executed once with CMCF shutdown
Goal is to get rid of the deprecated header and sponsoring configs and merge its data to the new sitebuilding config
Need to wait for Funkotron to map the correct fields before execution