### PR TITLE
Sitebuilding Migration and Inheritance on Scala2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,15 +8,15 @@ val buildNumber = Properties.envOrNone("BUILD_NUMBER")
 val isSnapshot = buildNumber.isEmpty
 val PlayVersion = "2.7.3"
 val AWSVersion = "1.11.631"
-val actualVersion: String = s"4.5.${buildNumber.getOrElse("0-local")}"
+val actualVersion: String = s"95.5.${buildNumber.getOrElse("0-local")}"
 
 def withTests(project: Project) = project % "test->test;compile->compile"
 
 val frontendCompilationSettings = Seq(
   organization := "de.welt",
-  scalaVersion := "2.12.10",
-  crossScalaVersions := Seq(scalaVersion.value, "2.13.0"),
-  version in ThisBuild := s"${actualVersion}_$PlayVersion${if (isSnapshot) "-SNAPSHOT" else ""}",
+  scalaVersion := "2.13.1",
+  crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
+  version in ThisBuild := s"${actualVersion}_$PlayVersion",
 
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
   javacOptions ++= Seq("-deprecation", "-source", "-opt:l:default"),
@@ -66,7 +66,7 @@ val clientDependencySettings = Seq(
     "com.kenshoo" %% "metrics-play" % "2.7.3_0.8.1",
 
     "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test,
-    "org.mockito" % "mockito-core" % vMockito % Test
+    "org.mockito" % "mockito-core" % vMockito % Test,
   )
 )
 

--- a/core/src/main/scala/de/welt/contentapi/core/client/services/aws/ssm/ParameterStore.scala
+++ b/core/src/main/scala/de/welt/contentapi/core/client/services/aws/ssm/ParameterStore.scala
@@ -7,7 +7,7 @@ import de.welt.contentapi.core.client.services.configuration.ApiConfiguration
 import de.welt.contentapi.utils.Loggable
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 class ParameterStore(region: Region) extends Loggable {

--- a/core/src/main/scala/de/welt/contentapi/core/client/services/configuration/ApiConfiguration.scala
+++ b/core/src/main/scala/de/welt/contentapi/core/client/services/configuration/ApiConfiguration.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions}
 import de.welt.contentapi.core.client.services.aws.ssm.ParameterStore
 import de.welt.contentapi.utils.Loggable
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
 
@@ -37,9 +37,9 @@ class ApiConfiguration extends Loggable {
   private def configFromParameterStore(path: String): Config = {
     val params = parameterStore.getPath(path)
     log.debug(s"[SSM] Loading config. path='$path'.")
-    val configMap = params.map {
+    val configMap: Map[String, String] = params.map {
       // remove the path prefix from ssm
-      case (key, value) ⇒ key.replaceFirst(path, "") → value
+      case (key: String, value: String) ⇒ key.replaceFirst(path, "") → value
     }
     ConfigFactory.parseMap(configMap.asJava, s"SSM param store @$path").resolve()
   }
@@ -123,7 +123,7 @@ class ApiConfiguration extends Loggable {
       log.info(s"Trying to read file ${file.getName} for AWS credentials.")
       Try(
         BasicProfileConfigLoader.INSTANCE.loadProfiles(file).getProfiles.asScala.map {
-          case (k, v) ⇒ k.replaceFirst("^profile ", "") → v
+          case (k: String, v: BasicProfile) => k.replaceFirst("^profile ", "") -> v
         }).recover {
         case th: Throwable ⇒
           log.info(s"Could not load ${file.getName}", th)

--- a/core/src/main/scala/de/welt/contentapi/core/client/services/configuration/Environment.scala
+++ b/core/src/main/scala/de/welt/contentapi/core/client/services/configuration/Environment.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.{Config, ConfigFactory}
 import de.welt.contentapi.utils.Loggable
 import play.api.Configuration
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 import scala.util.{Success, Try}
 

--- a/core/src/test/scala/de/welt/contentapi/core/client/services/aws/s3/S3ClientTest.scala
+++ b/core/src/test/scala/de/welt/contentapi/core/client/services/aws/s3/S3ClientTest.scala
@@ -1,10 +1,10 @@
 package de.welt.contentapi.core.client.services.aws.s3
 
+import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.{GetObjectRequest, S3Object, S3ObjectInputStream}
-import org.apache.commons.io.IOUtils
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatestplus.play.PlaySpec
 
@@ -16,13 +16,15 @@ class S3ClientTest extends PlaySpec {
     val service: S3Client = new S3Client(s3)
   }
 
+
   "S3Client" should {
     "pass requests to the underlying amazon client" in new Scope {
       Mockito.when(s3.getObject(ArgumentMatchers.any[GetObjectRequest]))
         .thenReturn(response)
+
+      //noinspection ScalaStyle
       Mockito.when(response.getObjectContent)
-        .thenReturn(new S3ObjectInputStream(
-          IOUtils.toInputStream("hello, world!", Charset.defaultCharset()), null))
+        .thenReturn(new S3ObjectInputStream(new ByteArrayInputStream("hello, world!".getBytes(Charset.defaultCharset())), null))
       val s3_response = service.get("foo", "bar")
 
       s3_response mustBe Some("hello, world!")

--- a/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiSiteBuildingTest.scala
+++ b/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiSiteBuildingTest.scala
@@ -1,19 +1,18 @@
 package de.welt.contentapi.pressed.client.converter
 
-import de.welt.contentapi.core.models.{ApiAsset, ApiElement, ApiReference}
-import de.welt.contentapi.pressed.models.{ApiSiteBuildingConfiguration}
-import de.welt.contentapi.raw.models
 import de.welt.contentapi.raw.models._
 import de.welt.testing.TestHelper.raw.channel.{emptyWithId, emptyWithIdAndChildren}
+import org.mockito.Mockito
 import org.scalatestplus.play.PlaySpec
 
+//noinspection ScalaStyle
 class Raw2ApiSiteBuildingTest extends PlaySpec {
 
-  val converter: RawToApiConverter = new RawToApiConverter(new InheritanceCalculator())
+  val rawToApiConverter: RawToApiConverter = new RawToApiConverter(new InheritanceCalculator())
 
   //noinspection ScalaStyle
   trait SiteBuildingTreeScope {
-
+    def spyRawToApiConverter = Mockito.spy(rawToApiConverter)
     // @formatter:off
 
     /**
@@ -24,8 +23,8 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
       *
       *
       *         (    0[root]   *S*    )
-      *         |            \        \
-      *      (10 *SM*)    (20 *M*)   (30 *m*)
+      *         |            \
+      *      (10 *SM*)    (20 *M*)
       *        |              \
       *      (100)         (200 *S*)
       *       |                \
@@ -34,14 +33,7 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
 
     // @formatter:on
 
-    /** 1XXX */
-    val node1000 = emptyWithId(1000)
-    node1000.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding()))
-
-    val node1000WithDeletedSitebuildingConf = emptyWithId(1000)
-    node1000WithDeletedSitebuildingConf.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))))
-
-    val node100 = emptyWithIdAndChildren(100, Seq(node1000, node1000WithDeletedSitebuildingConf))
+    val node100 = emptyWithIdAndChildren(100, Seq.empty)
 
     val node10 = emptyWithIdAndChildren(10, Seq(node100))
     node10.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
@@ -66,20 +58,20 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
     node2000.config = RawChannelConfiguration(siteBuilding = None)
 
     val node200 = emptyWithIdAndChildren(200, Seq(node2000))
-    node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(fields = Some(Map("header_label" -> "Label")))))
+    node200.config = RawChannelConfiguration()
 
     val node20 = emptyWithIdAndChildren(20, Seq(node200))
-    node20.config = RawChannelConfiguration(master = true, siteBuilding = None)
-
-    /** 3X */
-    val node30 = emptyWithId(30)
+    node20.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+      fields = Some(Map(
+        "header_slogan" -> "Header Slogan",
+        "sponsoring_slogan" -> "Sponsoring Slogan"
+      )),
+      sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/")))),
+      elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
+    )))
 
     /** root */
-    val root = emptyWithIdAndChildren(0, Seq(node10, node20, node30))
-    root.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
-      fields = Some(Map("header_slogan" -> "Slogan")),
-      sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/"))))
-    )))
+    val root = emptyWithIdAndChildren(0, Seq(node10, node20))
     root.updateParentRelations()
 
     import de.welt.contentapi.core.models.testImplicits.pathUpdater
@@ -87,77 +79,148 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
     root.updatePaths()
   }
 
-  "Sitebuilding Conversion WITHOUT master inheritance" must {
+  "calculateSiteBuilding()" should {
 
-    "be chosen if channel defines a sitebuilding field" in {
-      val channel = emptyWithId(1000)
-      channel.config = RawChannelConfiguration(siteBuilding = Some(models.RawChannelSiteBuilding(fields = Some(Map("header_label" -> "Label")))))
-      converter.calculateSiteBuilding(channel) mustBe Some(ApiSiteBuildingConfiguration(fields = Some(Map("header_label" -> "Label"))))
+    "look for a master and inherit `sponsoring_` values if channel.isMasterInheritanceEligible is true because no `sponsoring_` values are present" in new SiteBuildingTreeScope {
+      node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+        fields = Some(Map(
+          "header_slogan" -> "Header Slogan"
+        )),
+        sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/")))),
+        elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
+      )))
+
+      spyRawToApiConverter.calculateSiteBuilding(node200).get.unwrappedFields.get("sponsoring_slogan") mustBe Some("Sponsoring Slogan")
+      Mockito.verify(spyRawToApiConverter, Mockito.atMostOnce()).calculateMasterChannel(node200)
     }
 
-    "be chosen if channel defines a sitebuilding element" in {
+    "look for a master and inherit `header_` values if channel.isMasterInheritanceEligible is true because no `header` values are present" in new SiteBuildingTreeScope {
+      node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+        fields = Some(Map(
+          "sponsoring_slogan" -> "Sponsoring Slogan"
+        )),
+        sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/")))),
+        elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
+      )))
 
-      val channel = emptyWithId(1000)
-      channel.config = RawChannelConfiguration(siteBuilding = Some(models.RawChannelSiteBuilding(
-        elements = Some(Seq(
-          RawElement(
-            id = RawChannelElement.IdDefault,
-            `type` = "mood",
-            assets = Some(List(
-              RawAsset(
-                `type` = "image",
-                fields = Some(Map("key1" -> "value2", "key2" -> "value2"))
-              )
-            ))
-          )
-        )))
-      ))
-      converter.calculateSiteBuilding(channel) mustBe Some(ApiSiteBuildingConfiguration(
-        elements = Some(Seq(
-          ApiElement(
-            id = RawChannelElement.IdDefault,
-            `type` = "mood",
-            assets = Some(List(
-              ApiAsset(
-                `type` = "image",
-                fields = Some(Map("key1" -> "value2", "key2" -> "value2"))
-              )
-            ))
-          )
-        ))
-      ))
+      spyRawToApiConverter.calculateSiteBuilding(node200).get.unwrappedFields.get("header_slogan") mustBe Some("Header Slogan")
+      Mockito.verify(spyRawToApiConverter, Mockito.atMostOnce()).calculateMasterChannel(node200)
     }
 
-    "be chosen if channel defines a sub navigation (SectionReferences)" in {
-      val channel = emptyWithId(1000)
-      channel.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(sub_navigation = Some(Seq(RawSectionReference(path = Some("/path/")))))))
-      converter.calculateSiteBuilding(channel) mustBe Some(ApiSiteBuildingConfiguration(sub_navigation = Some(Seq(ApiReference(href = Some("/path/"))))))
+    "look for a master and inherit `elements` if channel.isMasterInheritanceEligible is true because no elements are present" in new SiteBuildingTreeScope {
+      node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+        fields = Some(Map(
+          "header_slogan" -> "Header Slogan",
+          "sponsoring_slogan" -> "Sponsoring Slogan"
+        )),
+        sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/")))),
+        elements = None
+      )))
+
+      spyRawToApiConverter.calculateSiteBuilding(node200).get.unwrappedElements.size mustBe 1
+      Mockito.verify(spyRawToApiConverter, Mockito.atMostOnce()).calculateMasterChannel(node200)
     }
+
+    "look for a master and inherit `sub_navigation` if channel.isMasterInheritanceEligible is true because no sub_navigation is present" in new SiteBuildingTreeScope {
+      node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+        fields = Some(Map(
+          "header_slogan" -> "Header Slogan",
+          "sponsoring_slogan" -> "Sponsoring Slogan"
+        )),
+        sub_navigation = None,
+        elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
+      )))
+
+      spyRawToApiConverter.calculateSiteBuilding(node200).get.unwrappedSubNavigation.size mustBe 1
+      Mockito.verify(spyRawToApiConverter, Mockito.atMostOnce()).calculateMasterChannel(node200)
+    }
+
+    "never look for a master and inherit values if channel.isMasterInheritanceEligible is false" in new SiteBuildingTreeScope {
+      node200.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
+        fields = Some(Map(
+          "header_slogan" -> "Header Slogan",
+          "sponsoring_slogan" -> "Sponsoring Slogan"
+        )),
+        sub_navigation = Some(Seq(RawSectionReference(Some("Label"), Some("/Path/")))),
+        elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
+      )))
+
+      spyRawToApiConverter.calculateSiteBuilding(node200).isDefined mustBe true
+      Mockito.verify(spyRawToApiConverter, Mockito.never()).calculateMasterChannel(node200)
+    }
+
+
+
   }
 
-  "Site Building Conversion WITH master inheritance" must {
+  "mergeSitebuildings()" should {
 
-    "be chosen if values are equal to constructor defaults (empty site building configuration)" in new SiteBuildingTreeScope {
-      converter.calculateSiteBuilding(node1000) mustBe converter.calculateSiteBuilding(node10)
+    "add `header_` fields from master if channel itself has no `header_` fields" in {
+      val channel = RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true"
+      )))
+
+      val master = RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      )))
+      rawToApiConverter.mergeSitebuildings(channel, master) mustBe RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      )))
     }
 
-    "be chosen if values are empty (deleted site building configuration)" in new SiteBuildingTreeScope {
-      converter.calculateSiteBuilding(node1000WithDeletedSitebuildingConf) mustBe converter.calculateSiteBuilding(node10)
+    "add `header_` fields from master if channel itself has `header_hidden = false` as only `header` field" in {
+      val channel = RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_hidden" -> "false"
+      )))
+
+      val master = RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      )))
+      rawToApiConverter.mergeSitebuildings(channel, master) mustBe RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      )))
     }
+
+    "add `sponsoring_` fields from master if channel itself has no `sponsoring_` fields" in {
+      val channel = RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "zukunftsfond"
+      )))
+
+      val master = RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "zukunftsfond",
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true"
+      )))
+      rawToApiConverter.mergeSitebuildings(channel, master) mustBe RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_logo" -> "zukunftsfond"
+      )))
+    }
+
+    "add elements from master if channel itself has no elements" in {
+      val channel = RawChannelSiteBuilding(elements = None)
+      val master = RawChannelSiteBuilding(elements = Some(Seq(RawElement())), fields = Some(Map.empty))
+      rawToApiConverter.mergeSitebuildings(channel, master) mustBe master
+    }
+
+    "add sub navi from master if channel itself has no sub navi" in {
+      val channel = RawChannelSiteBuilding(elements = None)
+      val master = RawChannelSiteBuilding(sub_navigation = Some(Seq(RawSectionReference())), fields = Some(Map.empty))
+      rawToApiConverter.mergeSitebuildings(channel, master) mustBe master
+    }
+
   }
 
-  "Site Building" must {
-
-    "not be inherited from parent that has a site building configuration but is not master" in new SiteBuildingTreeScope {
-      converter.calculateSiteBuilding(node2000) must not be converter.calculateSiteBuilding(node200)
-    }
-
-    "be inherited from next master even if the master has an empty site building configuration" in new SiteBuildingTreeScope {
-      converter.calculateSiteBuilding(node2000) mustBe empty
-    }
-
-    "be empty for a first level section that has no site building configuration (no inheritance from root)" in new SiteBuildingTreeScope {
-      converter.calculateSiteBuilding(node30) mustBe empty
-    }
-  }
 }

--- a/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiSiteBuildingTest.scala
+++ b/pressed/src/test/scala/de/welt/contentapi/pressed/client/converter/Raw2ApiSiteBuildingTest.scala
@@ -14,11 +14,11 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
   trait SiteBuildingTreeScope {
     def spyRawToApiConverter = Mockito.spy(rawToApiConverter)
 
-    // no sitebuilding
+    /** no sitebuilding */
     val channel = emptyWithIdAndChildren(200, Seq())
     channel.config = RawChannelConfiguration()
 
-    // master and has everything to inherit
+    /** master and has everything to inherit */
     val master = emptyWithIdAndChildren(20, Seq(channel))
     master.config = RawChannelConfiguration(siteBuilding = Some(RawChannelSiteBuilding(
       fields = Some(Map(
@@ -29,7 +29,7 @@ class Raw2ApiSiteBuildingTest extends PlaySpec {
       elements = Some(Seq(RawElement(id = "element id", `type` = "element type")))
     )))
 
-    /** fake tree */
+    /** fake root tree */
     val root = emptyWithIdAndChildren(0, Seq(master))
     root.updateParentRelations()
     import de.welt.contentapi.core.models.testImplicits.pathUpdater

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -394,8 +394,8 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty).filterNot(v => v._2.isBlank)
 
   def isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
-  def headerFields: Map[String, String] = fieldsFilteredBy("header_")
-  def sponsoringFields: Map[String, String] = fieldsFilteredBy("sponsoring_")
+  def headerFields: Map[String, String] = fieldsWithPrefix("header_")
+  def sponsoringFields: Map[String, String] = fieldsWithPrefix("sponsoring_")
 
   // `header_hidden` comes from CMCF internal state, where hidden can only be `true` of `false`, but will never be undefined or missing
   def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields.isEmpty
@@ -403,7 +403,7 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   def emptySubNavi: Boolean = unwrappedSubNavigation.isEmpty
   def emptyElements: Boolean = unwrappedElements.isEmpty
 
-  private def fieldsFilteredBy(prefix: String) = {
+  private def fieldsWithPrefix(prefix: String) = {
     this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith(prefix)).filterNot(v => v._2.isBlank)
   }
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -400,6 +400,11 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   // `header_hidden` comes from CMCF internal state, where hidden can only be `true` of `false`, but will never be undefined or missing
   def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields == Map.empty
   def emptySponsoring: Boolean = sponsoringFields.isEmpty
+  def emptySubNavi: Boolean = unwrappedSubNavigation.isEmpty
+  def emptyElements: Boolean = unwrappedElements.isEmpty
+
+  // if anything is empty, look for Master, that may inherit some values
+  def isMasterInheritanceEligible: Boolean = emptyHeader || emptySponsoring || emptySubNavi || emptyElements
 }
 
 /**

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -394,14 +394,18 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty).filterNot(v => v._2.isBlank)
 
   def isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
-  def headerFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("header_")).filterNot(v => v._2.isBlank)
-  def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_")).filterNot(v => v._2.isBlank)
+  def headerFields: Map[String, String] = fieldsFilteredBy("header_")
+  def sponsoringFields: Map[String, String] = fieldsFilteredBy("sponsoring_")
 
   // `header_hidden` comes from CMCF internal state, where hidden can only be `true` of `false`, but will never be undefined or missing
   def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields.isEmpty
   def emptySponsoring: Boolean = sponsoringFields == Map("sponsoring_hidden" -> "false") || sponsoringFields.isEmpty
   def emptySubNavi: Boolean = unwrappedSubNavigation.isEmpty
   def emptyElements: Boolean = unwrappedElements.isEmpty
+
+  private def fieldsFilteredBy(prefix: String) = {
+    this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith(prefix)).filterNot(v => v._2.isBlank)
+  }
 
   // if anything is empty, look for Master, that may inherit some values
   def isMasterInheritanceEligible: Boolean = emptyHeader || emptySponsoring || emptySubNavi || emptyElements

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -391,7 +391,7 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
 
   def unwrappedSubNavigation: Seq[RawSectionReference] = sub_navigation.getOrElse(Nil)
   def unwrappedElements: Seq[RawElement] = elements.getOrElse(Nil)
-  def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty)
+  def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty).filterNot(v => v._2.isBlank)
 
   /**
     * Channel Sitebuilding is empty when:
@@ -399,8 +399,8 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
     *  - it was already configured and deleted (consisting only of empty fields map)
     */
   def isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
-  def headerFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("header_"))
-  def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_"))
+  def headerFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("header_")).filterNot(v => v._2.isBlank)
+  def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_")).filterNot(v => v._2.isBlank)
 
   def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false")
   def emptySponsoring: Boolean = sponsoringFields.isEmpty

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -389,15 +389,21 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
                                   sub_navigation: Option[Seq[RawSectionReference]] = None,
                                   elements: Option[Seq[RawElement]] = None) {
 
-  lazy val unwrappedSubNavigation: Seq[RawSectionReference] = sub_navigation.getOrElse(Nil)
-  lazy val unwrappedElements: Seq[RawElement] = elements.getOrElse(Nil)
+  def unwrappedSubNavigation: Seq[RawSectionReference] = sub_navigation.getOrElse(Nil)
+  def unwrappedElements: Seq[RawElement] = elements.getOrElse(Nil)
+  def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty)
 
   /**
     * Channel Sitebuilding is empty when:
     *  - it has never been configured (default constructor)
     *  - it was already configured and deleted (consisting only of empty fields map)
     */
-  lazy val isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
+  def isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
+  def headerFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("header_"))
+  def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_"))
+
+  def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false")
+  def emptySponsoring: Boolean = sponsoringFields.isEmpty
 }
 
 /**

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -393,16 +393,12 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   def unwrappedElements: Seq[RawElement] = elements.getOrElse(Nil)
   def unwrappedFields: Map[String, String] = fields.getOrElse(Map.empty).filterNot(v => v._2.isBlank)
 
-  /**
-    * Channel Sitebuilding is empty when:
-    *  - it has never been configured (default constructor)
-    *  - it was already configured and deleted (consisting only of empty fields map)
-    */
   def isEmpty: Boolean = this == RawChannelSiteBuilding() || this == RawChannelSiteBuilding(fields = Some(Map.empty[String, String]))
   def headerFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("header_")).filterNot(v => v._2.isBlank)
   def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_")).filterNot(v => v._2.isBlank)
 
-  def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false")
+  // `header_hidden` comes from CMCF internal state, where hidden can only be `true` of `false`, but will never be undefined or missing
+  def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields == Map.empty
   def emptySponsoring: Boolean = sponsoringFields.isEmpty
 }
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -398,8 +398,8 @@ case class RawChannelSiteBuilding(fields: Option[Map[String, String]] = None,
   def sponsoringFields: Map[String, String] = this.fields.getOrElse(Map.empty).filter(v => v._1.startsWith("sponsoring_")).filterNot(v => v._2.isBlank)
 
   // `header_hidden` comes from CMCF internal state, where hidden can only be `true` of `false`, but will never be undefined or missing
-  def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields == Map.empty
-  def emptySponsoring: Boolean = sponsoringFields.isEmpty
+  def emptyHeader: Boolean = headerFields == Map("header_hidden" -> "false") || headerFields.isEmpty
+  def emptySponsoring: Boolean = sponsoringFields == Map("sponsoring_hidden" -> "false") || sponsoringFields.isEmpty
   def emptySubNavi: Boolean = unwrappedSubNavigation.isEmpty
   def emptyElements: Boolean = unwrappedElements.isEmpty
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -298,11 +298,11 @@ object RawReads {
     lazy val oldSponsoringFields: collection.Map[String, String] = fieldsFromOldSponsoring.getOrElse(Map.empty).toMap
     lazy val oldHeaderFields: collection.Map[String, String] = fieldsFromOldHeader.getOrElse(mutable.HashMap.empty).toMap
     lazy val renamedAndMergedOldFields: collection.Map[String, String] = oldSponsoringFields ++ oldHeaderFields
+    lazy val migrationHint: scala.collection.Map[String, String] = Map("migrated" -> "true")
 
     if (newSitebuilding.isDefined) {
       var siteBuilding = newSitebuilding.get
       if (siteBuilding.fields.getOrElse(Map.empty).contains("migrated")) {
-        println("already migrated, skipping")
         return newSitebuilding
       }
       def siteBuildingFields = siteBuilding.fields.getOrElse(Map.empty)
@@ -336,8 +336,6 @@ object RawReads {
       }
       **/
 
-
-      val migrationHint: scala.collection.Map[String, String] = Map("migrated" -> "true")
       val mergedFields: scala.collection.Map[String, String] = renamedAndMergedOldFields ++ siteBuildingFields ++ migrationHint
       val subNavi = siteBuilding.sub_navigation.orElse(oldHeader.flatMap(_.sectionReferences)) // new references win, old ones only as backup for migration
 
@@ -347,7 +345,7 @@ object RawReads {
       val oldReferences: Option[Seq[RawSectionReference]] = oldHeader.map(_.unwrappedSectionReferences)
       if (renamedAndMergedOldFields.nonEmpty || oldReferences.getOrElse(Nil).nonEmpty) {
         Some(RawChannelSiteBuilding(
-          fields = if (renamedAndMergedOldFields.nonEmpty) Some(renamedAndMergedOldFields.toMap) else None,
+          fields = if (renamedAndMergedOldFields.nonEmpty) Some(renamedAndMergedOldFields.toMap ++ migrationHint) else None,
           sub_navigation = if (oldReferences.getOrElse(Nil).nonEmpty) oldReferences else None,
           elements = None))
       } else

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/MigrationTests.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/MigrationTests.scala
@@ -35,7 +35,8 @@ class MigrationTests extends PlaySpec {
         "header_logo" -> "kompakt",
         "header_hidden" -> "false",
         "header_label" -> "header_old_section_name_label",
-        "header_href" -> "/header_old_section_name_header_link/"
+        "header_href" -> "/header_old_section_name_header_link/",
+        "migrated" -> "true"
       )
       sitebuilding.fields.getOrElse(Map.empty) mustBe migratedFields
     }
@@ -80,7 +81,8 @@ class MigrationTests extends PlaySpec {
         "sponsoring_logo_href" -> "/sponsoring_old_sponsoring_logo_link/",
         "sponsoring_slogan" -> "sponsoring_old_sponsoring_slogan",
         "sponsoring_hidden" -> "false",
-        "sponsoring_enclosure" -> "presented")
+        "sponsoring_enclosure" -> "presented",
+        "migrated" -> "true")
     }
 
     "sitebuilding references win over old ones" in {
@@ -393,7 +395,8 @@ class MigrationTests extends PlaySpec {
           |      "footer_legal": "",
           |      "footer_hidden": "",
           |      "footer_body": "",
-          |      "partner_header_body": ""
+          |      "partner_header_body": "",
+          |      "migrated" : "true"
           |    },
           |    "sub_navigation": [
           |      {

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/MigrationTests.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/MigrationTests.scala
@@ -1,0 +1,1052 @@
+package de.welt.contentapi.raw.models
+
+import org.scalatestplus.play.PlaySpec
+import play.api.libs.json.Json
+
+class MigrationTests extends PlaySpec {
+
+  import RawReads._
+
+  private final val emptyJson = "{}"
+
+  "Migration" must {
+    "migrate old header values to sitebuilding fields" in {
+      val header =
+        """{
+          |      "logo": "kompakt",
+          |      "slogan": "header_old_section_name_slogan",
+          |      "label": "header_old_section_name_label",
+          |      "hidden": false,
+          |      "adIndicator": true,
+          |      "sloganReference": {
+          |        "path": "/header_old_section_name_slogan_link/"
+          |      },
+          |      "headerReference": {
+          |        "path": "/header_old_section_name_header_link/"
+          |      }
+          |    }
+        """.stripMargin
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, None).get
+      val migratedFields = collection.Map(
+        "header_slogan_href" -> "/header_old_section_name_slogan_link/",
+        "header_slogan" -> "header_old_section_name_slogan",
+        "sponsoring_ad_indicator" -> "true",
+        "header_logo" -> "kompakt",
+        "header_hidden" -> "false",
+        "header_label" -> "header_old_section_name_label",
+        "header_href" -> "/header_old_section_name_header_link/"
+      )
+      sitebuilding.fields.getOrElse(Map.empty) mustBe migratedFields
+    }
+
+    "migrate old header references to sitebuilding references" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, None).get
+      sitebuilding.sub_navigation.map(_.size) mustBe Some(2)
+      sitebuilding.sub_navigation mustBe mheader.flatMap(_.sectionReferences)
+    }
+
+    "migrate old sponsoring to sitebuilding" in {
+      val json =
+        """{
+          |      "hidden": false,
+          |      "logo": "70-jahre-wams",
+          |      "slogan": "sponsoring_old_sponsoring_slogan",
+          |      "brandstation": "presented",
+          |      "link": {
+          |        "path": "/sponsoring_old_sponsoring_logo_link/"
+          |      }
+          |    }
+        """.stripMargin
+      val sponsoring = Json.parse(json).validate[RawSponsoringConfig].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(None, sponsoring, None).get
+      sitebuilding.fields.getOrElse(Map.empty) mustBe Map(
+        "sponsoring_logo" -> "70-jahre-wams",
+        "sponsoring_logo_href" -> "/sponsoring_old_sponsoring_logo_link/",
+        "sponsoring_slogan" -> "sponsoring_old_sponsoring_slogan",
+        "sponsoring_hidden" -> "false",
+        "sponsoring_enclosure" -> "presented")
+    }
+
+    "sitebuilding references win over old ones" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_old",
+          |          "path": "/unique_old/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+
+      val siteBuilding =
+        """{
+          |"sub_navigation": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_new",
+          |          "path": "/unique_new/"
+          |        }
+          |      ]
+          |}
+        """.stripMargin
+
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val msiteb = Json.parse(siteBuilding).validate[RawChannelSiteBuilding].asOpt
+
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, msiteb).get
+
+      sitebuilding.sub_navigation mustBe Some(Vector(
+        RawSectionReference(Some("header_old_subnavi_label_1"), Some("/header_old_subnavi_label_1_url/")),
+        RawSectionReference(Some("header_old_subnavi_label_2"), Some("/header_old_subnavi_label_2_url/")),
+        RawSectionReference(Some("unique_new"), Some("/unique_new/"))
+      ))
+    }
+
+    "old references are migrated if sitebuilding is empty" in {
+      val header =
+        """{
+          |     "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        },
+          |        {
+          |          "label": "unique_old",
+          |          "path": "/unique_old/"
+          |        }
+          |      ]
+          |    }
+        """.stripMargin
+
+      val siteBuilding =
+        """{
+          |"sub_navigation": []
+          |}
+        """.stripMargin
+
+      val mheader = Json.parse(header).validate[RawChannelHeader].asOpt
+      val msiteb = Json.parse(siteBuilding).validate[RawChannelSiteBuilding].asOpt
+
+      val sitebuilding = RawReads.sitebuildingMigration(mheader, None, msiteb).get
+
+      sitebuilding.sub_navigation mustBe Some(Vector(
+        RawSectionReference(Some("header_old_subnavi_label_1"), Some("/header_old_subnavi_label_1_url/")),
+        RawSectionReference(Some("header_old_subnavi_label_2"), Some("/header_old_subnavi_label_2_url/")),
+        RawSectionReference(Some("unique_old"), Some("/unique_old/"))
+      ))
+    }
+
+    "migrate old header dropdown to sitebuilding dropdown logo" in {
+      val json =
+        """
+          |{
+          |      "logo": "kompakt"
+          |}
+        """.stripMargin
+      val mHeader = Json.parse(json).validate[RawChannelHeader].asOpt
+      val json2 =
+        """{
+          |      "fields": {
+          |        "header_logo": "header_logo_escenic"
+          |      },
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-header_logo_escenic.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |}""".stripMargin
+      val mSiteb = Json.parse(json2).validate[RawChannelSiteBuilding].asOpt
+      val sitebuilding: RawChannelSiteBuilding = RawReads.sitebuildingMigration(mHeader, None, mSiteb).get
+      sitebuilding.unwrappedFields("header_logo") mustBe "kompakt"
+      sitebuilding.unwrappedFields("header_logo_escenic") mustBe "header_logo_escenic"
+      sitebuilding.elements.size mustBe 1
+
+    }
+    "migrate old sponsoring dropdown to sitebuilding dropdown logo" in {
+      val json =
+        """
+          |{
+          |      "logo": "kompakt"
+          |}
+        """.stripMargin
+      val mSponsoring = Json.parse(json).validate[RawSponsoringConfig].asOpt
+      val json2 =
+        """{
+          |      "fields": {
+          |        "sponsoring_logo": "sponsoring_logo_escenic"
+          |      },
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-header_logo_escenic.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |}""".stripMargin
+      val mSiteb = Json.parse(json2).validate[RawChannelSiteBuilding].asOpt
+      val sitebuilding = RawReads.sitebuildingMigration(None, mSponsoring, mSiteb).get
+      sitebuilding.unwrappedFields("sponsoring_logo") mustBe "kompakt"
+      sitebuilding.unwrappedFields("sponsoring_logo_escenic") mustBe "sponsoring_logo_escenic"
+      sitebuilding.elements.size mustBe 1
+
+    }
+
+
+  }
+
+  "Migration json compare" should {
+
+    "old completely filled, sitebuilding empty" in {
+      val json =
+        """{
+          |    "metadata": {
+          |      "title": "",
+          |      "description": "",
+          |      "sectionRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "contentRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "sectionBreadcrumbDisabled": false,
+          |      "keywords": []
+          |    },
+          |    "commercial": {
+          |      "contentTaboola": {
+          |        "showNetwork": true,
+          |        "showNews": true,
+          |        "showWeb": true,
+          |        "showWebExtended": true
+          |      },
+          |      "definesAdTag": false,
+          |      "definesVideoAdTag": false,
+          |      "showFallbackAds": true,
+          |      "disableAdvertisement": false
+          |    },
+          |    "articlePromotions": [
+          |      {
+          |        "contentId": "",
+          |        "type": "Advertorial"
+          |      }
+          |    ],
+          |    "header": {
+          |      "logo": "kompakt",
+          |      "slogan": "header_old_section_name_slogan",
+          |      "label": "header_old_section_name_label",
+          |      "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        }
+          |      ],
+          |      "hidden": false,
+          |      "adIndicator": true,
+          |      "sloganReference": {
+          |        "path": "/header_old_section_name_slogan_link/"
+          |      },
+          |      "headerReference": {
+          |        "path": "/header_old_section_name_header_link/"
+          |      }
+          |    },
+          |    "sponsoring": {
+          |      "hidden": false,
+          |      "logo": "70-jahre-wams",
+          |      "slogan": "sponsoring_old_sponsoring_slogan",
+          |      "brandstation": "sponsored",
+          |      "link": {
+          |        "path": "/sponsoring_old_sponsoring_logo_link/"
+          |      }
+          |    },
+          |    "siteBuilding": {
+          |      "fields": {
+          |        "header_label": "",
+          |        "header_logo": "",
+          |        "header_href": "",
+          |        "header_slogan": "",
+          |        "header_slogan_href": "",
+          |        "header_hidden": "",
+          |        "partner_header_button_label": "",
+          |        "partner_header_button_href": "",
+          |        "partner_header_mood_image": "",
+          |        "partner_header_logo": "",
+          |        "partner_header_hidden": "",
+          |        "sponsoring_logo": "",
+          |        "sponsoring_logo_href": "",
+          |        "sponsoring_slogan": "",
+          |        "sponsoring_ad_indicator": "",
+          |        "sponsoring_hidden": "",
+          |        "sponsoring_enclosure_hidden": "",
+          |        "sponsoring_enclosure": "",
+          |        "footer_button_label": "",
+          |        "footer_button_href": "",
+          |        "footer_slogan_label": "",
+          |        "footer_slogan_href": "",
+          |        "footer_mood_image": "",
+          |        "footer_logo": "",
+          |        "footer_legal": "",
+          |        "footer_hidden": "",
+          |        "footer_body": "",
+          |        "partner_header_body": ""
+          |      },
+          |      "sub_navigation": [],
+          |      "elements": []
+          |    },
+          |    "master": false,
+          |    "brand": false,
+          |    "theme": {
+          |      "name": ""
+          |    },
+          |    "content": {}
+          |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected =
+        """{
+          |    "fields": {
+          |      "header_label": "header_old_section_name_label",
+          |      "header_logo": "kompakt",
+          |      "header_logo_escenic": "",
+          |      "header_href": "/header_old_section_name_header_link/",
+          |      "header_slogan": "header_old_section_name_slogan",
+          |      "header_slogan_href": "/header_old_section_name_slogan_link/",
+          |      "header_hidden": "false",
+          |      "partner_header_button_label": "",
+          |      "partner_header_button_href": "",
+          |      "partner_header_mood_image": "",
+          |      "partner_header_logo": "",
+          |      "partner_header_hidden": "",
+          |      "sponsoring_logo": "70-jahre-wams",
+          |      "sponsoring_logo_escenic": "",
+          |      "sponsoring_logo_href": "/sponsoring_old_sponsoring_logo_link/",
+          |      "sponsoring_slogan": "sponsoring_old_sponsoring_slogan",
+          |      "sponsoring_ad_indicator": "true",
+          |      "sponsoring_hidden": "false",
+          |      "sponsoring_enclosure_hidden": "",
+          |      "sponsoring_enclosure": "sponsored",
+          |      "footer_button_label": "",
+          |      "footer_button_href": "",
+          |      "footer_slogan_label": "",
+          |      "footer_slogan_href": "",
+          |      "footer_mood_image": "",
+          |      "footer_logo": "",
+          |      "footer_legal": "",
+          |      "footer_hidden": "",
+          |      "footer_body": "",
+          |      "partner_header_body": ""
+          |    },
+          |    "sub_navigation": [
+          |      {
+          |        "label": "header_old_subnavi_label_1",
+          |        "path": "/header_old_subnavi_label_1_url/"
+          |      },
+          |      {
+          |        "label": "header_old_subnavi_label_2",
+          |        "path": "/header_old_subnavi_label_2_url/"
+          |      }
+          |    ],
+          |    "elements": []
+          |  }""".stripMargin
+
+      val expectedSitebuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+
+    "sitebuilding completely filled, old empty" in { // todo: here
+      val json =
+        """{
+          |    "metadata": {
+          |      "title": "",
+          |      "description": "",
+          |      "sectionRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "contentRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "sectionBreadcrumbDisabled": false,
+          |      "keywords": []
+          |    },
+          |    "commercial": {
+          |      "contentTaboola": {
+          |        "showNetwork": true,
+          |        "showNews": true,
+          |        "showWeb": true,
+          |        "showWebExtended": true
+          |      },
+          |      "definesAdTag": false,
+          |      "definesVideoAdTag": false,
+          |      "showFallbackAds": true,
+          |      "disableAdvertisement": false
+          |    },
+          |    "articlePromotions": [],
+          |    "header": {
+          |      "logo": "",
+          |      "slogan": "",
+          |      "label": "",
+          |      "sectionReferences": [],
+          |      "hidden": false,
+          |      "adIndicator": false
+          |    },
+          |    "sponsoring": {
+          |      "hidden": false
+          |    },
+          |    "siteBuilding": {
+          |      "fields": {
+          |        "header_label": "sitebuilding_custom_header_label",
+          |        "header_logo": "sitebuilding_custom_header_logo_ece_id",
+          |        "header_href": "/sitebuilding_custom_header_link/",
+          |        "header_slogan": "sitebuilding_custom_header_slogan",
+          |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+          |        "header_hidden": "false",
+          |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+          |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+          |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+          |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+          |        "partner_header_hidden": "false",
+          |        "sponsoring_logo": "sitebuilding_header_sponsoring_logo_ece_id",
+          |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+          |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+          |        "sponsoring_ad_indicator": "true",
+          |        "sponsoring_hidden": "false",
+          |        "sponsoring_enclosure_hidden": "false",
+          |        "sponsoring_enclosure": "presented",
+          |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+          |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+          |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+          |        "footer_slogan_href": "",
+          |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+          |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+          |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+          |        "footer_hidden": "false",
+          |        "general_breadcrumb_hidden": "",
+          |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+          |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+          |      },
+          |      "sub_navigation": [
+          |        {
+          |          "label": "sitebuilding_subnavi_label_1",
+          |          "path": "/sitebuilding_subnavi_href_1/"
+          |        },
+          |        {
+          |          "label": "sitebuilding_subnavi_label_2",
+          |          "path": "/sitebuilding_subnavi_href_2/"
+          |        }
+          |      ],
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "sponsoring_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "94x35",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/0096585617-ci94x35-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "16x9",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/2281353017-ci16x9-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |    },
+          |    "master": false,
+          |    "brand": false,
+          |    "theme": {
+          |      "name": ""
+          |    },
+          |    "content": {}
+          |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected =
+        """{
+          |      "fields": {
+          |        "migrated": "true",
+          |        "header_label": "sitebuilding_custom_header_label",
+          |        "header_logo": "",
+          |        "header_logo_escenic": "sitebuilding_custom_header_logo_ece_id",
+          |        "header_href": "/sitebuilding_custom_header_link/",
+          |        "header_slogan": "sitebuilding_custom_header_slogan",
+          |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+          |        "header_hidden": "false",
+          |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+          |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+          |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+          |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+          |        "partner_header_hidden": "false",
+          |        "sponsoring_logo": "",
+          |        "sponsoring_logo_escenic": "sitebuilding_header_sponsoring_logo_ece_id",
+          |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+          |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+          |        "sponsoring_ad_indicator": "true",
+          |        "sponsoring_hidden": "false",
+          |        "sponsoring_enclosure_hidden": "false",
+          |        "sponsoring_enclosure": "presented",
+          |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+          |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+          |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+          |        "footer_slogan_href": "",
+          |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+          |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+          |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+          |        "footer_hidden": "false",
+          |        "general_breadcrumb_hidden": "",
+          |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+          |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+          |      },
+          |      "sub_navigation": [
+          |        {
+          |          "label": "sitebuilding_subnavi_label_1",
+          |          "path": "/sitebuilding_subnavi_href_1/"
+          |        },
+          |        {
+          |          "label": "sitebuilding_subnavi_label_2",
+          |          "path": "/sitebuilding_subnavi_href_2/"
+          |        }
+          |      ],
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "sponsoring_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "94x35",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/0096585617-ci94x35-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "16x9",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/2281353017-ci16x9-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |    }""".stripMargin
+
+      val expectedSitebuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+
+    "both completely filled" in { // todo: here
+      val json =
+        """{
+          |    "metadata": {
+          |      "title": "",
+          |      "description": "",
+          |      "sectionRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "contentRobots": {
+          |        "noIndex": false,
+          |        "noFollow": false
+          |      },
+          |      "sectionBreadcrumbDisabled": false,
+          |      "keywords": []
+          |    },
+          |    "commercial": {
+          |      "contentTaboola": {
+          |        "showNetwork": true,
+          |        "showNews": true,
+          |        "showWeb": true,
+          |        "showWebExtended": true
+          |      },
+          |      "definesAdTag": false,
+          |      "definesVideoAdTag": false,
+          |      "showFallbackAds": true,
+          |      "disableAdvertisement": false
+          |    },
+          |    "articlePromotions": [],
+          |    "header": {
+          |      "logo": "kompakt",
+          |      "slogan": "header_old_section_name_slogan",
+          |      "label": "header_old_section_name_label",
+          |      "sectionReferences": [
+          |        {
+          |          "label": "header_old_subnavi_label_1",
+          |          "path": "/header_old_subnavi_label_1_url/"
+          |        },
+          |        {
+          |          "label": "header_old_subnavi_label_2",
+          |          "path": "/header_old_subnavi_label_2_url/"
+          |        }
+          |      ],
+          |      "hidden": false,
+          |      "adIndicator": true,
+          |      "sloganReference": {
+          |        "path": "/header_old_section_name_slogan_link/"
+          |      },
+          |      "headerReference": {
+          |        "path": "/header_old_section_name_header_link/"
+          |      }
+          |    },
+          |    "sponsoring": {
+          |      "hidden": false,
+          |      "logo": "70-jahre-wams",
+          |      "slogan": "sponsoring_old_sponsoring_slogan",
+          |      "brandstation": "presented",
+          |      "link": {
+          |        "path": "/sponsoring_old_sponsoring_logo_link/"
+          |      }
+          |    },
+          |    "siteBuilding": {
+          |      "fields": {
+          |        "header_label": "sitebuilding_custom_header_label",
+          |        "header_logo": "sitebuilding_custom_header_logo_ece_id",
+          |        "header_href": "/sitebuilding_custom_header_link/",
+          |        "header_slogan": "sitebuilding_custom_header_slogan",
+          |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+          |        "header_hidden": "false",
+          |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+          |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+          |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+          |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+          |        "partner_header_hidden": "false",
+          |        "sponsoring_logo": "sitebuilding_header_sponsoring_logo_ece_id",
+          |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+          |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+          |        "sponsoring_ad_indicator": "true",
+          |        "sponsoring_hidden": "false",
+          |        "sponsoring_enclosure_hidden": "false",
+          |        "sponsoring_enclosure": "presented",
+          |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+          |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+          |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+          |        "footer_slogan_href": "",
+          |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+          |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+          |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+          |        "footer_hidden": "false",
+          |        "general_breadcrumb_hidden": "",
+          |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+          |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+          |      },
+          |      "sub_navigation": [
+          |        {
+          |          "label": "sitebuilding_subnavi_label_1",
+          |          "path": "/sitebuilding_subnavi_href_1/"
+          |        },
+          |        {
+          |          "label": "sitebuilding_subnavi_label_2",
+          |          "path": "/sitebuilding_subnavi_href_2/"
+          |        }
+          |      ],
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "sponsoring_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "94x35",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/3506586347-ci94x35-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "16x9",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/0771358307-ci16x9-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |    },
+          |    "master": false,
+          |    "brand": false,
+          |    "theme": {
+          |      "name": ""
+          |    },
+          |    "content": {}
+          |  }""".stripMargin
+
+      val rawConfig: Option[RawChannelConfiguration] = Json.parse(json).validate[RawChannelConfiguration](RawReads.rawChannelConfigurationReads).asOpt
+      val sitebuilding = rawConfig.flatMap(_.siteBuilding).orNull
+      val expected =
+        """{
+          |      "fields": {
+          |        "migrated": "true",
+          |        "header_label": "sitebuilding_custom_header_label",
+          |        "header_logo": "kompakt",
+          |        "header_logo_escenic": "sitebuilding_custom_header_logo_ece_id",
+          |        "header_href": "/sitebuilding_custom_header_link/",
+          |        "header_slogan": "sitebuilding_custom_header_slogan",
+          |        "header_slogan_href": "/sitebuilding_custom_header_slogan_link/",
+          |        "header_hidden": "false",
+          |        "partner_header_button_label": "sitebuilding_partner_header_module_cta_button",
+          |        "partner_header_button_href": "/sitebuilding_partner_header_module_cta_button_href/",
+          |        "partner_header_mood_image": "sitebuilding_partner_header_module_mood_ece_id",
+          |        "partner_header_logo": "sitebuilding_partner_header_module_logo_ece_id",
+          |        "partner_header_hidden": "false",
+          |        "sponsoring_logo": "70-jahre-wams",
+          |        "sponsoring_logo_escenic": "sitebuilding_header_sponsoring_logo_ece_id",
+          |        "sponsoring_logo_href": "/sitebuilding_header_sponsoring_logo_link/",
+          |        "sponsoring_slogan": "sitebuilding_header_sponsoring_slogan",
+          |        "sponsoring_ad_indicator": "true",
+          |        "sponsoring_hidden": "false",
+          |        "sponsoring_enclosure_hidden": "false",
+          |        "sponsoring_enclosure": "presented",
+          |        "footer_button_label": "sitebuilding_partner_footer_modul_cta_button",
+          |        "footer_button_href": "/sitebuilding_partner_footer_modul_cta_button_href/",
+          |        "footer_slogan_label": "sitebuilding_partner_footer_modul_slogan",
+          |        "footer_slogan_href": "",
+          |        "footer_mood_image": "sitebuilding_partner_footer_modul_mood_ece_id",
+          |        "footer_logo": "sitebuilding_partner_footer_modul_logo_ece_id",
+          |        "footer_legal": "sitebuilding_partner_footer_modul_legal_text",
+          |        "footer_hidden": "false",
+          |        "footer_body": "sitebuilding_partner_footer_modul_body_text",
+          |        "partner_header_body": "sitebuilding_partner_header_module_body_text"
+          |      },
+          |      "sub_navigation": [
+          |        {
+          |          "label": "sitebuilding_subnavi_label_1",
+          |          "path": "/sitebuilding_subnavi_href_1/"
+          |        },
+          |        {
+          |          "label": "sitebuilding_subnavi_label_2",
+          |          "path": "/sitebuilding_subnavi_href_2/"
+          |        }
+          |      ],
+          |      "elements": [
+          |        {
+          |          "id": "channel_element",
+          |          "type": "header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_custom_header_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "sponsoring_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_header_sponsoring_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_header_module_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "partner_header_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "94x35",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_header_module_mood_ece_id/3506586347-ci94x35-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_logo",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "orig",
+          |                "source": "https://www.welt.de/bin/logo-sitebuilding_partner_footer_modul_logo_ece_id.jpg"
+          |              }
+          |            }
+          |          ]
+          |        },
+          |        {
+          |          "id": "channel_element",
+          |          "type": "footer_mood_image",
+          |          "assets": [
+          |            {
+          |              "type": "image",
+          |              "fields": {
+          |                "crop": "16x9",
+          |                "source": "https://www.welt.de/img/mobilesitebuilding_partner_footer_modul_mood_ece_id/0771358307-ci16x9-wWIDTH/image.jpg"
+          |              }
+          |            }
+          |          ]
+          |        }
+          |      ]
+          |    }""".stripMargin
+
+      val expectedSitebuilding: RawChannelSiteBuilding = Json.parse(expected).validate[RawChannelSiteBuilding].get
+      expectedSitebuilding mustBe sitebuilding
+    }
+  }
+
+
+  def getFields(stuff: Map[String,String]): Seq[(String, String)] = {
+    stuff.toSeq.sortBy(_._1).filterNot(_._1 == "migrated")
+  }
+}

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawChannelSiteBuildingTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawChannelSiteBuildingTest.scala
@@ -6,8 +6,6 @@ class RawChannelSiteBuildingTest extends PlaySpec {
 
   "unwrappedFields()" should {
 
-    //  def emptySponsoring: Boolean = sponsoringFields.isEmpty
-
     "filter empty values" in {
       RawChannelSiteBuilding(fields = Some(Map("sponsoring_slogan" -> ""))).headerFields mustBe Map.empty
     }

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawChannelSiteBuildingTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawChannelSiteBuildingTest.scala
@@ -1,0 +1,107 @@
+package de.welt.contentapi.raw.models
+
+import org.scalatestplus.play.PlaySpec
+
+class RawChannelSiteBuildingTest extends PlaySpec {
+
+  "unwrappedFields()" should {
+
+    //  def emptySponsoring: Boolean = sponsoringFields.isEmpty
+
+    "filter empty values" in {
+      RawChannelSiteBuilding(fields = Some(Map("sponsoring_slogan" -> ""))).headerFields mustBe Map.empty
+    }
+  }
+
+  "isEmpty()" should {
+
+    "be true if has constructor values" in {
+      RawChannelSiteBuilding().isEmpty mustBe true
+    }
+
+    "be true if only `fields` are present but they are empty" in {
+      RawChannelSiteBuilding(fields = Some(Map.empty)).isEmpty mustBe true
+    }
+
+  }
+
+  "headerFields()" should {
+
+    "return only fields that start with `header_`" in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      ))).headerFields mustBe Map(
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      )
+    }
+
+    "return only `header_` fields with values other than `empty String`" in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "",
+        "header_hidden" -> "true"
+      ))).headerFields mustBe Map(
+        "header_hidden" -> "true"
+      )
+    }
+  }
+
+  "sponsoringFields()" should {
+
+    "return only fields that start with `sponsoring_`" in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      ))).sponsoringFields mustBe Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true"
+      )
+    }
+
+    "return only `sponsoring_` fields with values other than `empty String`" in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "",
+        "sponsoring_hidden" -> "true"
+      ))).sponsoringFields mustBe Map(
+        "sponsoring_hidden" -> "true"
+      )
+    }
+  }
+
+  // CMCF keeps its internal state in a Map[String,String]
+  // And because within the internal state the header can only be hidden or not, its never undefined, and therefore at least this header field is present
+  // so we have to do a validation which header fields are contained, and if its only `header_hidden = false` we say that the header is actually empty
+  "emptyHeader()" should {
+
+    "return true if `headerFields()` only returns `header_hidden = false` " in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true",
+        "header_hidden" -> "false"
+      ))).emptyHeader mustBe true
+    }
+
+    "return true if `headerFields()` returns an empty Map " in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "sponsoring_slogan" -> "Winamp - it really whips the llama's ass",
+        "sponsoring_hidden" -> "true"
+      ))).emptyHeader mustBe true
+    }
+  }
+
+  "emptySponsoring()" should {
+    "return true if no field starts with `sponsoring_`" in {
+      RawChannelSiteBuilding(fields = Some(Map(
+        "header_logo" -> "zukunftsfond",
+        "header_hidden" -> "true"
+      ))).emptySponsoring mustBe true
+
+    }
+  }
+
+
+}

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
@@ -28,7 +28,8 @@ class RawReadsTest extends PlaySpec {
           |}""".stripMargin
       Json.parse(json)
         .validate[RawChannelConfiguration](rawChannelConfigurationReads)
-        .asOpt mustBe Some(RawChannelConfiguration(header = Some(RawChannelHeader(logo = Some("foo.png")))))
+        .asOpt
+        .flatMap(_.header) mustBe Some(RawChannelHeader(logo = Some("foo.png")))
     }
 
     "ignore known empty properties" in {
@@ -41,7 +42,8 @@ class RawReadsTest extends PlaySpec {
           |}""".stripMargin
       Json.parse(json)
         .validate[RawChannelConfiguration](rawChannelConfigurationReads)
-        .asOpt mustBe Some(RawChannelConfiguration(header = Some(RawChannelHeader(logo = Some("foo.png")))))
+        .asOpt
+        .flatMap(_.header) mustBe Some(RawChannelHeader(logo = Some("foo.png")))
     }
 
     "ignore known empty properties with empty values" in {
@@ -54,7 +56,8 @@ class RawReadsTest extends PlaySpec {
           |}""".stripMargin
       Json.parse(json)
         .validate[RawChannelConfiguration](rawChannelConfigurationReads)
-        .asOpt mustBe Some(RawChannelConfiguration(header = Some(RawChannelHeader(logo = Some("foo.png")))))
+        .asOpt
+        .flatMap(_.header) mustBe Some(RawChannelHeader(logo = Some("foo.png")))
     }
   }
 


### PR DESCRIPTION
- adds migration for Sponsoring and Header fields to Sitebuilding within the `RawReads.scala`
- changes `calculated inheritance` to include Sitebuilding fields, filtered by their prefixes, e.g. `sponsoring_`
-

# TODO:
- use this Version in CMCF `build.sbt` and remove migration part in `RawReads.scala` after a short time
- Wait for funkotron to be ready for sitebuilding as primary config source
- change versioning back in `build.sbt`
